### PR TITLE
feat: Added support of API interaction within the web-app

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build & run docker
+        env:
+          API_URL: ${{ secrets.API_URL }}
+          API_LOGIN: ${{ secrets.API_LOGIN }}
+          API_PWD: ${{ secrets.API_PWD }}
         run: docker-compose up -d --build
       - name: Ping app inside the container
         run: nc -vz localhost 8050

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,13 @@ ENV PYTHONUNBUFFERED 1
 COPY ./requirements.txt /usr/src/app/requirements.txt
 
 # install dependencies
-RUN pip install --upgrade pip setuptools wheel \
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y git \
+    && pip install --upgrade pip setuptools wheel \
     && pip install -r /usr/src/app/requirements.txt \
-    && rm -rf /root/.cache/pip
+    && apt-get purge --autoremove -y git \
+    && rm -rf /root/.cache/pip \
+    && rm -rf /var/lib/apt/lists/*
 
 # copy project
 COPY app/ /usr/src/app/

--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ pip install -r pyro-platform/requirements.txt
 
 ## Usage
 
+Beforehand, you will need to set a few environment variables either manually or by writing an `.env` file in the root directory of this project, like in the example below:
+
+```
+API_URL=http://my-api.myhost.com
+API_LOGIN=my_secret_login
+API_PWD=my_very_secret_password
+
+```
+Those values will allow your web server to connect to our [API](https://github.com/pyronear/pyro-api), which is mandatory for your local server to be fully operational.
+
 #### Plain dash server
 
 You can run the web server using the following commands:

--- a/app/config.py
+++ b/app/config.py
@@ -1,3 +1,6 @@
 import os
 
 DEBUG: bool = os.environ.get('DEBUG', '') != 'False'
+API_URL: str = os.getenv('API_URL')
+API_LOGIN: str = os.getenv('API_LOGIN')
+API_PWD: str = os.getenv('API_PWD')

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,4 @@
+from .api import api_client
+
+
+__all__ = ['api_client']

--- a/app/services/api.py
+++ b/app/services/api.py
@@ -1,0 +1,11 @@
+from pyroclient import Client
+import config as cfg
+
+
+__all__ = ['api_client']
+
+
+if any(not isinstance(val, str) for val in [cfg.API_URL, cfg.API_LOGIN, cfg.API_PWD]):
+    raise ValueError("The following environment variables need to be set: 'API_URL', 'API_LOGIN', 'API_PWD'")
+
+api_client = Client(cfg.API_URL, cfg.API_LOGIN, cfg.API_PWD)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,7 @@ services:
       - ./app/:/usr/src/app/
     ports:
       - "8050:8050"
+    environment:
+      - API_URL=${API_URL}
+      - API_LOGIN=${API_LOGIN}
+      - API_PWD=${API_PWD}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.7'
 services:
   web:
     build: .
-    command: python main.py
+    command: python main.py --host 0.0.0.0
     volumes:
       - ./app/:/usr/src/app/
     ports:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ dash-bootstrap-components>=0.10.6
 dash-leaflet>=0.1.4
 plotly>=4.7.1
 gunicorn>=20.0.4
+pyroclient@git+https://github.com/pyronear/pyro-api.git#egg=pyroclient&subdirectory=client


### PR DESCRIPTION
Hey there :wave: 

As discussed earlier with @pechouc, we figured you might need to be able to access API features later. This PR does that exactly, now in your `main` or any other module, you can do the following:
```
from services import api_client
# then you can use any method of the client like so 
# api_client.blabla_my_method()
```

The supported methods of the API client are available in its documentation over here: https://pyronear.org/pyro-api/

Small details about authentication:
1. Currently I set them as environment variables, check the readme (suggestion: create a .env file with those variables and use the docker option to be able to test it just like in production).
2. On the long-term, you could use that as an authentication mechanism --> when the user accesses the platform, she/he enters some creds that are passed down to instantiate the `api_client` (any wrong creds will throw an error)

Successfully merging this PR will close #19 

Any feedback is welcome!