### PR TITLE
fix: Fixed gunicorn process on Heroku

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,5 +96,6 @@ jobs:
           screen -S temp-screen -p 0 -X stuff "export API_LOGIN=$API_LOGIN^M"
           screen -S temp-screen -p 0 -X stuff "export API_PWD=$API_PWD^M"
           screen -S temp-screen -p 0 -X stuff "gunicorn --workers 1 -b 0.0.0.0:8050 --chdir ./app main:server^M"
+          sleep 5
       - name: Ping the gunicorn process port
         run: nc -vz localhost 8050

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,16 +85,16 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-      - name: Set env variables
+      - name: Run gunicorn
         env:
           API_URL: ${{ secrets.API_URL }}
           API_LOGIN: ${{ secrets.API_LOGIN }}
           API_PWD: ${{ secrets.API_PWD }}
         run: |
-          echo API_URL=${API_URL} > .env
-          echo API_LOGIN=${API_LOGIN} >> .env
-          echo API_PWD=${API_PWD} >> .env
-      - name: Run gunicorn
-        run: screen -d -m gunicorn --workers 1 -b 0.0.0.0:8050 --chdir ./app main:server
+          screen -dmS temp-screen
+          screen -S temp-screen -p 0 -X stuff "export API_URL=$API_URL^M"
+          screen -S temp-screen -p 0 -X stuff "export API_LOGIN=$API_LOGIN^M"
+          screen -S temp-screen -p 0 -X stuff "export API_PWD=$API_PWD^M"
+          screen -S temp-screen -p 0 -X stuff "gunicorn --workers 1 -b 0.0.0.0:8050 --chdir ./app main:server^M"
       - name: Ping the gunicorn process port
         run: nc -vz localhost 8050

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,6 +86,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Run gunicorn
-        run: gunicorn --workers 1 -b 0.0.0.0:8050 --chdir ./app main:server
+        env:
+          API_URL: ${{ secrets.API_URL }}
+          API_LOGIN: ${{ secrets.API_LOGIN }}
+          API_PWD: ${{ secrets.API_PWD }}
+        run: screen -d -m gunicorn --workers 1 -b 0.0.0.0:8050 --chdir ./app main:server
       - name: Ping the gunicorn process port
         run: nc -vz localhost 8050

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,11 +85,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-      - name: Run gunicorn
+      - name: Run gunicorn & ping the process
         env:
           API_URL: ${{ secrets.API_URL }}
           API_LOGIN: ${{ secrets.API_LOGIN }}
           API_PWD: ${{ secrets.API_PWD }}
-        run: gunicorn --workers 1 -b 0.0.0.0:8050 --chdir ./app main:server
-      - name: Ping the gunicorn process port
-        run: nc -vz localhost 8050
+        run: |
+          screen -d -m gunicorn --workers 1 -b 0.0.0.0:8050 --chdir ./app main:server
+          nc -vz localhost 8050

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,6 +86,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Run gunicorn
-        run: screen -d -m gunicorn --workers 1 -b 0.0.0.0:8050 --chdir ./app main:server
+        run: gunicorn --workers 1 -b 0.0.0.0:8050 --chdir ./app main:server
       - name: Ping the gunicorn process port
         run: nc -vz localhost 8050

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,11 +85,16 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-      - name: Run gunicorn & ping the process
+      - name: Set env variables
         env:
           API_URL: ${{ secrets.API_URL }}
           API_LOGIN: ${{ secrets.API_LOGIN }}
           API_PWD: ${{ secrets.API_PWD }}
         run: |
-          screen -d -m gunicorn --workers 1 -b 0.0.0.0:8050 --chdir ./app main:server
-          nc -vz localhost 8050
+          echo API_URL=${API_URL} > .env
+          echo API_LOGIN=${API_LOGIN} >> .env
+          echo API_PWD=${API_PWD} >> .env
+      - name: Run gunicorn
+        run: screen -d -m gunicorn --workers 1 -b 0.0.0.0:8050 --chdir ./app main:server
+      - name: Ping the gunicorn process port
+        run: nc -vz localhost 8050

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,3 +61,31 @@ jobs:
         run: docker-compose up -d --build
       - name: Ping app inside the container
         run: nc -vz localhost 8050
+
+  docker-gunicorn:
+    runs-on: ubuntu-latest
+    needs: install-deps
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+          architecture: x64
+      - name: Cache python modules
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-deps-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-deps-${{ matrix.python-version }}-
+            ${{ runner.os }}-deps-
+            ${{ runner.os }}-
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run gunicorn
+        run: screen -d -m gunicorn --workers 1 -b 0.0.0.0:8050 --chdir ./app main:server
+      - name: Ping the gunicorn process port
+        run: nc -vz localhost 8050

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,6 +90,6 @@ jobs:
           API_URL: ${{ secrets.API_URL }}
           API_LOGIN: ${{ secrets.API_LOGIN }}
           API_PWD: ${{ secrets.API_PWD }}
-        run: screen -d -m gunicorn --workers 1 -b 0.0.0.0:8050 --chdir ./app main:server
+        run: gunicorn --workers 1 -b 0.0.0.0:8050 --chdir ./app main:server
       - name: Ping the gunicorn process port
         run: nc -vz localhost 8050

--- a/app/main.py
+++ b/app/main.py
@@ -40,6 +40,8 @@ from services import api_client
 app = dash.Dash(__name__, external_stylesheets=[dbc.themes.UNITED])
 app.title = 'Pyronear - Monitoring platform'
 app.config.suppress_callback_exceptions = True
+# Gunicorn will be looking for the server attribute of this module
+server = app.server
 
 # We create a rough layout that will be filled by the first callback based on the url path
 app.layout = html.Div([dcc.Location(id='url', refresh=False),


### PR DESCRIPTION
Hey there :wave: 

Some of you noticed that the Heroku app has been crashing recently. So I investigated and fixed the problem:
- first of all, the crash is not due to our recent commits (most likely, one of the dependencies released a new version and we only have lower bound constraints)
- while for dev, we run the server either with python or docker (which is verified in the unittest), the Heroku app is run using the [Procfile](https://github.com/pyronear/pyro-platform/blob/master/Procfile). The corresponding command runs the server differently in a subprocess (using [gunicorn](https://gunicorn.org/) for the curious ones)
- so the actual command to run the production server was not tested, I added this in the CI workflow
- now, to fix the issue, the production app is run looking for the `server` attribute of the `app` object in the main module. A few commits ago, this was working by itself, so that's why I suspect a change in dependency versions. Anyway, I fixed the issue by forcing the creation of a `server` attribute of the `app` object


Any feedback is welcome!