### PR TITLE
Alert acknowledgement

### DIFF
--- a/app/alerts.py
+++ b/app/alerts.py
@@ -173,14 +173,14 @@ def build_alerts_elements(img_url, alert_status, alert_metadata):
                     # And takes value True once checked
                     dcc.Markdown("---"),
                     html.Div(id='acknowledge_alert_div_{}'.format(alert_id),
-                             children=[dbc.FormGroup([
-                                            dbc.Checkbox(id='acknowledge_alert_checkbox_{}'.format(alert_id),
-                                                         className="form-check-input"),
-                                            dbc.Label("Confirmer la prise en compte de l'alerte",
-                                                      html_for='acknowledge_alert_checkbox_{}'.format(alert_id),
-                                                      className="form-check-label")],
-                                            check=True,
-                                            inline=True)])
+                             children=[
+                                dbc.FormGroup([dbc.Checkbox(id='acknowledge_alert_checkbox_{}'.format(alert_id),
+                                                            className="form-check-input"),
+                                               dbc.Label("Confirmer la prise en compte de l'alerte",
+                                                         html_for='acknowledge_alert_checkbox_{}'.format(alert_id),
+                                                         className="form-check-label")],
+                                              check=True,
+                                              inline=True)])
                 ])])]
         alerts_markers_layer = dl.LayerGroup(children=alerts_markers, id='alerts_markers')
     else:

--- a/app/alerts.py
+++ b/app/alerts.py
@@ -168,7 +168,19 @@ def build_alerts_elements(value, alert_metadata):
                     html.Button("Afficher les données de détection",
                                 id=("display_alert_frame_btn{}".format(alert_id)),  # Setting a unique btn id
                                 n_clicks=0,
-                                className="btn btn-danger")
+                                className="btn btn-danger"),
+                    # Adding an alert acknowledgement checkbox which has value False by default
+                    # And takes value True once checked
+                    dcc.Markdown("---"),
+                    html.Div(id='acknowledge_alert_div_{}'.format(alert_id),
+                             children=[dbc.FormGroup([
+                                            dbc.Checkbox(id='acknowledge_alert_checkbox_{}'.format(alert_id),
+                                                         className="form-check-input"),
+                                            dbc.Label("Confirmer la prise en compte de l'alerte",
+                                                      html_for='acknowledge_alert_checkbox_{}'.format(alert_id),
+                                                      className="form-check-label")],
+                                            check=True,
+                                            inline=True)])
                 ])])]
         alerts_markers_layer = dl.LayerGroup(children=alerts_markers, id='alerts_markers')
     else:

--- a/app/main.py
+++ b/app/main.py
@@ -163,6 +163,20 @@ def region_click_alerts(feature, radio_button_value):
         else:
             return None
 
+@app.callback(Output('acknowledge_alert_div_{}'.format(alert_id), 'children'),
+              [Input('acknowledge_alert_checkbox_{}'.format(alert_id), 'checked')])
+def acknowledge_alert(checkbox_checked):
+    if not checkbox_checked:
+        return [dbc.FormGroup([dbc.Checkbox(id='acknowledge_alert_checkbox_{}'.format(alert_id),
+                                            className="form-check-input"),
+                               dbc.Label("Confirmer la prise en compte de l'alerte",
+                                         html_for='acknowledge_alert_checkbox_{}'.format(alert_id),
+                                         className="form-check-label")],
+                              check=True,
+                              inline=True)]
+    elif checkbox_checked:
+        return [html.P("Prise en compte de l'alerte confirmée")]
+
 # ------------------------------------------------------------------------------
 # Callbacks related to the "Niveau de Risque" page
 

--- a/app/main.py
+++ b/app/main.py
@@ -325,10 +325,10 @@ def display_alert_frame_metadata(n_clicks_marker, img_url):
 
 @app.callback(
     Output('interval-component', 'disabled'),
-    [Input("display_alert_frame_btn{}".format(alert_id), 'n_clicks')])
+    [Input("alert_marker_{}".format(alert_id), 'n_clicks')])
 def callback_func_start_stop_interval(n_clicks):
     '''
-    This one detects the number of clicks the user made on a display_alert_frame_btn.
+    This one detects the number of clicks the user made on an alert marker.
     If 1 click is made, the function disables the interval component.
     '''
     if n_clicks is not None and n_clicks > 0:

--- a/app/main.py
+++ b/app/main.py
@@ -164,6 +164,7 @@ def region_click_alerts(feature, radio_button_value):
         else:
             return None
 
+
 @app.callback(Output('acknowledge_alert_div_{}'.format(alert_id), 'children'),
               [Input('acknowledge_alert_checkbox_{}'.format(alert_id), 'checked')])
 def acknowledge_alert(checkbox_checked):

--- a/app/utils.py
+++ b/app/utils.py
@@ -98,7 +98,7 @@ def build_legend_box(app_page=None):
         # Historique des feux
         legend_body.append(html.Div([html.Div(html.Img(src=past_fire_img_url, style=img_style),
                                               style=image_div_style),
-                                     html.Div(html.P('Feu passé'),
+                                     html.Div(html.P('Incendie passé'),
                                               style=text_div_style)]))
 
         # Alerte
@@ -110,7 +110,7 @@ def build_legend_box(app_page=None):
     elif app_page == 'risks':
         legend_body = [html.Div([html.Div(html.Img(src=past_fire_img_url, style=img_style),
                                           style=image_div_style),
-                                 html.Div(html.P('Feu passé'),
+                                 html.Div(html.P('Incendie passé'),
                                           style=text_div_style)])]
 
     legend_id = 'legend_' + app_page
@@ -164,7 +164,7 @@ def get_old_fire_positions(dpt_code=None):
                                       position=(lat, lon),
                                       icon=icon,
                                       children=[dl.Tooltip(f"Date: {date}"),
-                                                dl.Popup([html.H2(f'Feu du {date}'),
+                                                dl.Popup([html.H4(f'Incendie du {date}'),
                                                           html.P(f'Commune : {location}'),
                                                           html.P(f'Type : {daynight}')])
                                                 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pandas>=0.24.2
 numpy>=1.18.4
 dash>=1.16.2
 dash-bootstrap-components>=0.10.6
-dash-leaflet>=0.1.4
+dash-leaflet==0.1.4
 gunicorn>=20.0.4
 Flask-Caching>=1.3.3
 pyroclient@git+https://github.com/pyronear/pyro-api.git#egg=pyroclient&subdirectory=client


### PR DESCRIPTION
# Goal of the PR 

- Main goal of this PR is to add the checkbox that allows the user to acknowledge an alert when he has clicked on the marker and looks at the associated popup. 

- This PR also brings two small fixes:
  - Rewording of historic fire markers;
  - Changing the required version of `dash-leaflet` from ">=0.1.4" to "==0.1.4". My guess is that the Heroku machine was pip installing the "0.1.12" version which does not support the `dlx.choropleth` object anymore, so that the "Niveaux de risque" map could not be displayed.

# Main changes 

- Addition of the checkbox object in the popup of the alert marker 

- Creation of the callback that erases the checkbox once it is checked and changes the related message

- Modification of the last callback that disables the `dcc.Interval()` component
  - The interval component is now disabled as soon as the user clicks on the alert marker 
  - Goal is to avoid the alert to be reloaded after the user has checked the acknowledgement checkbox 

# Screenshots 

1. The user clicks on the alert marker (NB: interval component is disabled from this point on)

![Capture d’écran 2020-12-13 à 09 35 55](https://user-images.githubusercontent.com/63041127/102007270-e4686d80-3d27-11eb-90a5-b7e776ecdfa4.png)

2. The user checks the box to acknowledge the reception of the alert

![Capture d’écran 2020-12-13 à 09 36 06](https://user-images.githubusercontent.com/63041127/102007273-e7fbf480-3d27-11eb-8b54-36e21eaef8a1.png)

3. The user clicks on other buttons (any button on the "Alertes" map) 

![Capture d’écran 2020-12-13 à 09 36 16](https://user-images.githubusercontent.com/63041127/102007279-ef230280-3d27-11eb-8a8f-9e747439c0a1.png)

4. The user can click again on the alert marker and the checkbox is not accessible anymore

![Capture d’écran 2020-12-13 à 09 36 19](https://user-images.githubusercontent.com/63041127/102007281-f34f2000-3d27-11eb-89e9-5750e1fd86d5.png)

# Question 

With this preliminary solution, if the user acknowledges the alert, moves to the "Niveaux de Risques" dashboard and comes back to the "Alertes" map, the alert data is reloaded and the acknowledgement checkbox can again be checked. I think it is because we are re-instantiating the interval component as part of the "Alertes" map.

I guess we will be able to bring a more solid solution to this issue once we can add an `if` statement in the callback that verifies whether the `is_acknowledge` field has already been changed to True or not. But at the moment, I am not sure to see a good solution to this problem without making the API call, etc. 

Do we agree to move forward with this imperfect solution for the demo-day and come back to it with a proper use of the client in the callback later on? 

cc @Akilditu @frgfm 