### PR TITLE
revert to where master was before #44

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -601,18 +601,14 @@ def callback_func_start_stop_interval(n_clicks):
     ],
     Input("interval-component-alert-screen", "n_intervals"),
     [
-        State("url", "pathname"),
         State("store_live_alerts_data", "data"),
         State("last_displayed_event_id", "data"),
     ],
 )
-def update_alert_screen(n_intervals, pathname, live_alerts, last_displayed_event_id):
+def update_alert_screen(n_intervals, live_alerts, last_displayed_event_id):
     """
     -- Update elements related to the Alert Screen page when the interval component "alert-screen" is triggered --
     """
-    if not pathname == "/alert-screen":
-        last_displayed_event_id = None
-
     if live_alerts is None:
         style_to_display = build_no_alert_detected_screen()
         return (
@@ -704,7 +700,6 @@ def update_images_for_doubt_removal(n_intervals, last_displayed_event_id, dict_i
         "http://placeimg.com/625/225/animals",
         "http://placeimg.com/625/225/nature"
     ]
-
     return list_url_images[n_intervals % len(list_url_images)]
 
 


### PR DESCRIPTION
Hello everyone

Sorry, after further investigation, I did a typo in #44: wrote "alert-screen" instead of "alert_screen". In apparence, the trick was working, but in truth it was not + the logic behind it does not work after further consideration. 

This PR reverts back to where master was before #44. The bug described in it remains and I will investigate more soon.