### PR TITLE
Alert erasing button

### DIFF
--- a/app/alerts.py
+++ b/app/alerts.py
@@ -248,13 +248,19 @@ def build_alerts_elements(images_url_live_alerts, live_alerts, map_style):
     all_alerts = pd.read_json(live_alerts)
 
     if all_alerts.empty:
-
+        # When there is no live alert to display, we return a alert header button that will remain hidden
         hidden_header_alert_button = html.Div(
             html.Button(
                 id=f'alert_button_{map_style}'
             ),
             style={'display': 'none'}
         )
+
+        # This is to ensure that the "click_new_alerts_button" callback gets triggered with n_clicks=0 and hides the
+        # blank user selection area, letting the map take the full width of the screen
+
+        # (It can be interesting to test returning [] instead of [hidden_header_alert_button] and erase all alerts one
+        # by one if explanations are unclear)
 
         return [hidden_header_alert_button], [], '#054546', 'Surveillez les départs de feux', []
 
@@ -456,6 +462,19 @@ def build_alert_modal(event_id, device_id, lat, lon, site_name, urls):
 
 
 def display_alert_selection_area(n_clicks):
+    """
+    Used in main.py in the "click_new_alerts_button" callback, this function takes as input the number of clicks on the
+    alert header button (in the top-right corner of the map) and returns the appropriate:
+
+    - width of the user selection area column on the left-hand side of the map;
+    - width of the map;
+    - style (being displayed or not) of the alert header button;
+    - style (being displayed or not) of the alert selection area.
+
+    If the number of clicks is 0, the user selection area is fully hidden and the button is displayed on the map. On the
+    other hand, if the number of clicks is stricly above 0, the various attributes are set so as to let the user sele-
+    ction area appear.
+    """
     if n_clicks > 0:
         # Defining col width for both user selection area and map
         md_user = 3
@@ -468,7 +487,6 @@ def display_alert_selection_area(n_clicks):
         alert_selection_area_style = {}
 
     else:
-        print('hello')
         md_user = 0
         md_map = 12
         alert_button_status = {}
@@ -481,14 +499,12 @@ def build_individual_alert_components(live_alerts, alert_frame_urls):
     """
     This function builds the user selection area containing the alert list
 
-    - it first sets the column sizes of each block (user area and map);
     - it creates the alerts_list based on live alerts data;
     - it creates the vision angle polygons of each alert that should be displayed;
     - it instantiates the modal corresponding to each live alert.
 
     To do so, it takes three arguments:
 
-    - the number of clicks on the alert button;
     - the live alerts data filling the alert_list;
     - the URL addresses of alert frames, gathered by event_id in the alert_frame_urls dictionary.
     """

--- a/app/homepage.py
+++ b/app/homepage.py
@@ -246,6 +246,8 @@ def build_login_modal():
     dal object which prevent the user from closing the modal respectively by clicking next to it and by pressing the
     Escape key.
     """
+    print('modal being built')
+
     return dbc.Modal(
         [
             dbc.ModalBody(
@@ -346,7 +348,7 @@ def Homepage():
 
                     html.Div(id="alert_overview_area"),
 
-                    html.Div(id='new_alerts_selection_list'),
+                    html.Div(id='new_alerts_selection_list', style={'display': 'none'}),
                     # Placeholder containing the detection data for any alert of interest
                     html.P(id="hp_alert_frame_metadata")],
                     id='user_selection_column',
@@ -368,9 +370,19 @@ def Homepage():
                     html.Div(id='login_zoom_and_center', style={'display': 'none'}),
                     html.Div(id='alert_zoom_and_center', style={'display': 'none'}),
 
+                    html.Div(id='alert_overview_style_zoom', style={'display': 'none'}),
+                    html.Div(id='alert_overview_style_closing_buttons', style={'display': 'none'}),
+                    html.Div(id='alert_overview_style_erase_buttons', style={'display': 'none'}),
+
+                    html.Div(id='update_live_alerts_data_workflow', style={'display': 'none'}),
+                    html.Div(id='update_live_alerts_data_erase_buttons', style={'display': 'none'}),
+
+                    html.Div(id='update_live_alerts_frames_workflow', style={'display': 'none'}),
+                    html.Div(id='update_live_alerts_frames_erase_buttons', style={'display': 'none'}),
+
                     # Hidden div storing the webscocket message sent by the API
                     html.Div(id="msg", style={'display': 'none'}),
-                    WebSocket(id="ws", url="wss://platform.pyronear.org//wss"),
+                    WebSocket(id="ws") # url="wss://platform.pyronear.org//wss"),
                 ],
                     id='map_column',
                     md=12),

--- a/app/homepage.py
+++ b/app/homepage.py
@@ -382,7 +382,7 @@ def Homepage():
 
                     # Hidden div storing the webscocket message sent by the API
                     html.Div(id="msg", style={'display': 'none'}),
-                    WebSocket(id="ws") # url="wss://platform.pyronear.org//wss"),
+                    WebSocket(id="ws", url="wss://platform.pyronear.org//wss"),
                 ],
                     id='map_column',
                     md=12),

--- a/app/homepage.py
+++ b/app/homepage.py
@@ -370,13 +370,16 @@ def Homepage():
                     html.Div(id='login_zoom_and_center', style={'display': 'none'}),
                     html.Div(id='alert_zoom_and_center', style={'display': 'none'}),
 
+                    # Placeholders for the three inputs that can affect the style attribute of the alert overview area
                     html.Div(id='alert_overview_style_zoom', style={'display': 'none'}),
                     html.Div(id='alert_overview_style_closing_buttons', style={'display': 'none'}),
                     html.Div(id='alert_overview_style_erase_buttons', style={'display': 'none'}),
 
+                    # Placeholders for the two inputs that can affect the stored live alert data
                     html.Div(id='update_live_alerts_data_workflow', style={'display': 'none'}),
                     html.Div(id='update_live_alerts_data_erase_buttons', style={'display': 'none'}),
 
+                    # Placeholders for the two inputs that can affect the stored live alert frame URLs
                     html.Div(id='update_live_alerts_frames_workflow', style={'display': 'none'}),
                     html.Div(id='update_live_alerts_frames_erase_buttons', style={'display': 'none'}),
 

--- a/app/homepage.py
+++ b/app/homepage.py
@@ -246,7 +246,6 @@ def build_login_modal():
     dal object which prevent the user from closing the modal respectively by clicking next to it and by pressing the
     Escape key.
     """
-    print('modal being built')
 
     return dbc.Modal(
         [

--- a/app/main.py
+++ b/app/main.py
@@ -74,8 +74,8 @@ from homepage import Homepage
 # From other Python files, we import some functions needed for interactivity
 from homepage import choose_map_style, display_alerts_frames
 from risks import build_risks_geojson_and_colorbar
-from alerts import build_alerts_elements, get_site_devices_data, build_individual_alert_components,\
-     build_alert_overview, display_alert_selection_area
+from alerts import build_alerts_elements, get_site_devices_data, build_individual_alert_components, \
+    build_alert_overview, display_alert_selection_area
 from utils import choose_layer_style, build_filters_object, build_historic_markers, build_legend_box
 
 # Importing the pre-instantiated Pyro-API client
@@ -683,6 +683,7 @@ def close_alert_overview_intermediary(n_clicks):
 
     else:
         return 'hidden'
+
 
 @app.callback(
     Output('alert_overview_area', 'style'),


### PR DESCRIPTION
Hello everyone! 

# Brief description of the PR

This PR aims at introducing two new features in the overview area of each alert/event:

- a button to close the overview and come back to the selection of the alerts;
- a button to erase an alert from the platform for the rest of the browser session. 

These simple interactions required a bit of work, essentially in `main.py`, as several outputs are now determined by a multitude of inputs (not only the center and zoom attributes of the map anymore). It also required to modify the `build_individual_alert_components` in `alerts.py`, some of its outputs being transferred to a new function (`display_alert_selection_area`). 

I have tried to comment the code as much as possible but let me know if you have any question of course!

# Screenshots

- Two alerts are initially displayed on the platform

![Capture d’écran 2021-05-24 à 08 53 46](https://user-images.githubusercontent.com/63041127/119308629-9019d000-bc6d-11eb-8c01-cdb5864e1597.png)

- As usual, we click on the alert button in the top-right corner of the map and then, select one of the alerts which lets the overview appear on the left-hand side of the map

![Capture d’écran 2021-05-24 à 08 54 16](https://user-images.githubusercontent.com/63041127/119308670-a1fb7300-bc6d-11eb-8656-a7f8527746be.png)

- By clicking on "Fermer l'aperçu de l'alerte", one can close the alert overview 

![Capture d’écran 2021-05-24 à 08 55 11](https://user-images.githubusercontent.com/63041127/119308775-c0fa0500-bc6d-11eb-81de-5f82c5e4151e.png)

- After reopening it (cf. second screenshot) and clicking on "Ne plus voir cette alerte", only 1 alert is displayed by the platform now

![Capture d’écran 2021-05-24 à 08 56 05](https://user-images.githubusercontent.com/63041127/119308881-e2f38780-bc6d-11eb-8bba-d5e84bcb7fbe.png)

- We can open the remaining alert overview

![Capture d’écran 2021-05-24 à 08 56 57](https://user-images.githubusercontent.com/63041127/119308997-00c0ec80-bc6e-11eb-8dfb-ec899bd24ef5.png)

- And we can do the same for this alert, no alert being displayed on the platform (back to its initial, no-alert state)

![Capture d’écran 2021-05-24 à 08 57 38](https://user-images.githubusercontent.com/63041127/119309079-19c99d80-bc6e-11eb-9f74-1626280043d4.png)

# Question

I don't know if you have the same issue but as you can see on the screenshots, the map doesn't load properly when I build the app locally with Docker. Using `python3 app/main.py" works (slightly) better and the deployed platform seems to display the map correctly, so it should not be too big an issue. But still, it does not help with the debugging...