### PR TITLE
Small debugging

### DIFF
--- a/app/alerts.py
+++ b/app/alerts.py
@@ -247,8 +247,6 @@ def build_alerts_elements(images_url_live_alerts, live_alerts, map_style, blocke
     alerts_markers = []
     all_alerts = pd.read_json(live_alerts)
 
-    all_alerts = all_alerts[~all_alerts['event_id'].isin(blocked_event_ids['event_ids'])].copy()
-
     if all_alerts.empty:
         # When there is no live alert to display, we return a alert header button that will remain hidden
         hidden_header_alert_button = html.Div(
@@ -264,7 +262,9 @@ def build_alerts_elements(images_url_live_alerts, live_alerts, map_style, blocke
         # (It can be interesting to test returning [] instead of [hidden_header_alert_button] and erase all alerts one
         # by one if explanations are unclear)
 
-        return [hidden_header_alert_button], [], '#054546', 'Surveillez les départs de feux', []
+        return [hidden_header_alert_button], [], '#054546', 'Surveillez les départs de feux'
+
+    all_alerts = all_alerts[~all_alerts['event_id'].isin(blocked_event_ids['event_ids'])].copy()
 
     all_events = all_alerts.drop_duplicates(['id', 'event_id']).groupby('event_id').head(1)  # Get unique events
     for _, row in all_events.iterrows():
@@ -514,10 +514,10 @@ def build_individual_alert_components(live_alerts, alert_frame_urls, blocked_eve
     # Creating the alert_list based on live_alerts
     all_alerts = pd.read_json(live_alerts)
 
-    all_alerts = all_alerts[~all_alerts['event_id'].isin(blocked_event_ids['event_ids'])].copy()
-
     if all_alerts.empty:
         return [], [], []
+
+    all_alerts = all_alerts[~all_alerts['event_id'].isin(blocked_event_ids['event_ids'])].copy()
 
     all_events = all_alerts.drop_duplicates(['id', 'event_id']).groupby('event_id').head(1)  # Get unique events
 

--- a/app/homepage.py
+++ b/app/homepage.py
@@ -370,15 +370,8 @@ def Homepage():
                     # Placeholders for the three inputs that can affect the style attribute of the alert overview area
                     html.Div(id='alert_overview_style_zoom', style={'display': 'none'}),
                     html.Div(id='alert_overview_style_closing_buttons', style={'display': 'none'}),
-                    html.Div(id='alert_overview_style_erase_buttons', style={'display': 'none'}),
+                    html.Div(id='alert_overview_style_erase_buttons', style={'display': 'none'})
 
-                    # Placeholders for the two inputs that can affect the stored live alert data
-                    dcc.Store(id='update_live_alerts_data_workflow', data={}),
-                    dcc.Store(id='update_live_alerts_data_erase_buttons', data={}),
-
-                    # Placeholders for the two inputs that can affect the stored live alert frame URLs
-                    dcc.Store(id='update_live_alerts_frames_workflow', data={}),
-                    dcc.Store(id='update_live_alerts_frames_erase_buttons', data={})
                 ],
                     id='map_column',
                     md=12),

--- a/app/main.py
+++ b/app/main.py
@@ -96,6 +96,21 @@ app.layout = html.Div(
         dcc.Location(id="url", refresh=False),
         html.Div(id="page-content", style={"height": "100%"}),
 
+        # Placeholders for the two inputs that can affect the stored live alert data
+        dcc.Store(id='update_live_alerts_data_workflow', data={}, storage_type="session"),
+        dcc.Store(id='update_live_alerts_data_erase_buttons', data={}, storage_type="session"),
+
+        # Placeholders for the two inputs that can affect the stored live alert frame URLs
+        dcc.Store(id='update_live_alerts_frames_workflow', data={}, storage_type="session"),
+        dcc.Store(id='update_live_alerts_frames_erase_buttons', data={}, storage_type="session"),
+
+        # Storage component which contains data relative devices
+        dcc.Store(
+            id="devices_data_storage",
+            storage_type="session",
+            data=requests.get('https://api.pyronear.org/devices/', headers=api_client.headers).json()
+        ),
+
         # Main interval that fetches API alerts data
         dcc.Interval(id="main_api_fetch_interval", interval=15 * 1000),
 
@@ -114,13 +129,6 @@ app.layout = html.Div(
         # Session storage component to avoid re-opening the login modal at each refresh
         # [NOT SUCCESSFUL YET]
         dcc.Store(id='login_storage', storage_type='session', data={'login': 'no'}),
-
-        # Storage component which contains data relative devices
-        dcc.Store(
-            id="devices_data_storage",
-            storage_type="session",
-            data=requests.get('https://api.pyronear.org/devices/', headers=api_client.headers).json()
-        ),
 
         # Storage component which contains data relative to site devices
         dcc.Store(


### PR DESCRIPTION
The aim of this PR is to: 

- Correct for the error message that says "A nonexistent object was used in an `Output` of a Dash callback. The id of this object is `update_live_alerts_data_workflow` and the property is `data`." and currently appears when opening the platform locally;

- Correct for bugs that appear when there is only one alert / event being displayed and one clicks on the "Ne plus voir cette alerte" button. These are related to the way the `build_alerts_components` and `build_individual_alerts_components` functions were written in `alerts.py`.

**Warning:** It might be that the first change (moving placeholders from `homepage.py` to `main.py`) creates another error message, which I have seen a few times but cannot recreate anymore. It was related to the `select_alert_frame_to_display` callback and basically said that the `individual_alert_frame_storage` component associated with the alert / event being displayed had not been created before being used as a `State`. This does not prevent the alert from being displayed on the platform but no image appears in the alert modal when opening it for the first time. 

@Akilditu, could you please counter-check this debugging proposal and see if you observe the error message locally (the one described in the warning)? 🙏 