### PR TITLE
Various edits for demo

### DIFF
--- a/app/alert_screen.py
+++ b/app/alert_screen.py
@@ -21,8 +21,10 @@ import dash_html_components as html
 
 from alerts import retrieve_site_from_device_id
 
+
 # ----------------------------------------------------------------------------------------------------------------------
 # CONTENT
+
 def build_no_alert_detected_screen():
     """
     The following function builds the no alert screen.
@@ -60,7 +62,7 @@ def build_alert_detected_screen(img_url, last_alert, site_devices_data):
     # Retrieve the name of the site from the device id
     try:
         site_name = retrieve_site_from_device_id(device_id, site_devices_data)
-    except:
+    except Exception:
         site_name = ''
 
     # Get azimuth from last_alert

--- a/app/alert_screen.py
+++ b/app/alert_screen.py
@@ -19,6 +19,7 @@ import dash_bootstrap_components as dbc
 import dash_core_components as dcc
 import dash_html_components as html
 
+from alerts import retrieve_site_from_device_id
 
 # ----------------------------------------------------------------------------------------------------------------------
 # CONTENT
@@ -40,7 +41,7 @@ def build_no_alert_detected_screen():
     return style
 
 
-def build_alert_detected_screen(img_url, last_alert):
+def build_alert_detected_screen(img_url, last_alert, site_devices_data):
     """
     This function is used in the main.py file to create the alert screen when its on, i.e. when there is an alert
     ongoing.
@@ -56,8 +57,14 @@ def build_alert_detected_screen(img_url, last_alert):
     # Get device id for last_alert
     device_id = last_alert["device_id"]
 
+    # Retrieve the name of the site from the device id
+    try:
+        site_name = retrieve_site_from_device_id(device_id, site_devices_data)
+    except:
+        site_name = ''
+
     # Get azimuth from last_alert
-    azimuth = round(last_alert["azimuth"], 1)
+    azimuth = round(last_alert["yaw"], 1)
 
     # Background image
     background_image = html.Img(
@@ -78,10 +85,10 @@ def build_alert_detected_screen(img_url, last_alert):
         style={"height": "100%"},
     )
 
-    # Detection frames
+    # Detection frame
     alert_frame = html.Img(
         id="alert_frame",
-        src=img_url,
+        src=img_url[-1],
         style={
             "position": "relative",
             "width": "100%",
@@ -104,10 +111,9 @@ def build_alert_detected_screen(img_url, last_alert):
     # Alert metadata div
     alert_metadata_div = html.Div(
         children=[
-            html.P("Tour: Serre en Don"),
-            html.P("Coordonnées de la tour: {}, {}".format(lat, lon)),
-            html.P("Id de caméra: {}".format(device_id)),
-            html.P("Azimuth: {}".format(azimuth)),
+            html.P("Coordonnées de la tour : {}, {}".format(lat, lon)),
+            html.P("Id de caméra : {}".format(device_id)),
+            html.P("Azimuth : {}".format(azimuth)),
         ]
     )
 
@@ -117,7 +123,7 @@ def build_alert_detected_screen(img_url, last_alert):
         children=[
             html.Div(
                 html.P(
-                    "DFCI: KD62D6.5",
+                    f"Tour : {site_name}",
                 ),
                 style={
                     "font-size": "2vw",
@@ -231,7 +237,7 @@ def AlertScreen():
     """
     layout = html.Div(
         children=[
-            dcc.Interval(id="interval-component-alert-screen", interval=3 * 1000),
+            dcc.Interval(id="interval-component-alert-screen", interval=10 * 1000),
             html.Div(id="core_layout_alert_screen", children=[]),
         ],
         style={

--- a/app/alerts.py
+++ b/app/alerts.py
@@ -104,6 +104,7 @@ def retrieve_site_from_device_id(device_id, site_devices_data):
 
     raise Exception('Device ID not found in site devices data.')
 
+
 # ----------------------------------------------------------------------------------------------------------------------
 # Sites markers
 # The following block is used to fetch and display on the map the positions of detection units.
@@ -549,7 +550,7 @@ def build_individual_alert_components(live_alerts, alert_frame_urls, blocked_eve
         device_id = row['device_id']
         try:
             site_name = retrieve_site_from_device_id(device_id, site_devices_data)
-        except:
+        except Exception:
             site_name = ''
 
         alert_selection_button = html.Div([

--- a/app/main.py
+++ b/app/main.py
@@ -26,14 +26,13 @@ It is built around 5 main sections:
 - Running the web-app server, which allows to launch the app via the Terminal command.
 """
 
-import time
-from pyroclient import Client
-
-
 # ----------------------------------------------------------------------------------------------------------------------
 # IMPORTS
 
 # --- General imports
+
+# From the pyroclient package
+from pyroclient import Client
 
 # Main Dash imports, used to instantiate the web-app and create callbacks (ie. to generate interactivity)
 import os
@@ -362,15 +361,11 @@ def update_live_alerts_data(
     string should be completed but more details can be found in the comments below.
     """
 
-    start_time = time.time()
-
     # Fetching live alerts where is_acknowledged is False
     response = api_client.get_ongoing_alerts().json()
 
     # If there is no alert, we prevent the callback from updating anything
     if len(response) == 0:
-
-        print(time.time() - start_time)
         raise PreventUpdate
 
     # We store all alerts in a DataFrame and we want to select "live alerts",
@@ -414,8 +409,6 @@ def update_live_alerts_data(
 
     # Is there any live alert to display?
     if live_alerts.empty:
-
-        print(time.time() - start_time)
         # If not, we do not update any of the callback's output
         raise PreventUpdate
 
@@ -484,8 +477,6 @@ def update_live_alerts_data(
             # - the storage component that contains alert data in JSON format;
             # - the storage component that contains the dictionary with detection frame URLs;
             # - the storage component that serves as source of truth for the list of already loaded alerts
-
-            print(time.time() - start_time)
 
             return live_alerts, dict_images_url_live_alerts, {'loaded_frames': new_loaded_frames}, 5 * 1000
 
@@ -563,8 +554,6 @@ def update_live_alerts_data(
 
                     live_alerts = live_alerts.to_json(orient='records')
 
-                    print(time.time() - start_time)
-
                     # We update all outputs
                     return [
                         live_alerts,
@@ -579,8 +568,6 @@ def update_live_alerts_data(
 
                     # We would like to only update the list of alert frames being displayed and not all the components
                     # To keep track of the frame URLs that have been loaded, we also update the list of loaded alert IDs
-
-                    print(time.time() - start_time)
                     return [
                         dash.no_update,
                         dict_images_url_live_alerts,
@@ -1470,6 +1457,7 @@ def update_alert_frame_main(alert_frame_update_new_event, alert_frame_update_int
     elif input_id == 'alert_frame_update_interval':
 
         return alert_frame_update_interval, dash.no_updates
+
 
 # ----------------------------------------------------------------------------------------------------------------------
 # RUNNING THE WEB-APP SERVER

--- a/app/main.py
+++ b/app/main.py
@@ -1380,7 +1380,7 @@ def update_alert_screen(n_intervals, blocked_event_ids, devices_data, site_devic
                 img_url = ""
 
                 try:
-                    img_url = api_client.get_media_url(last_alert["media_id"]).json()["url"]
+                    img_url = api_client.get_media_url(row["media_id"]).json()["url"]
 
                 except Exception:
                     pass


### PR DESCRIPTION
Hello, 

This PR aims at: 

- enabling a simplified but a priori functional version of the big alert screen;
- (temporarily?) disabling the display of historic fire markers;
- extending the delay for loading the initial alerts data when the app is opened;
- displaying the site name that corresponds to each alert everywhere on the platform. 

Thanks in advance for the review!