### PR TITLE
fix: fetch only alerts for unacknowledged events

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -250,8 +250,8 @@ def update_live_alerts_data(
     user_token = user_headers["Authorization"].split(" ")[1]
     api_client.token = user_token
 
-    # Fetch the last 5 unacknowledged events and associated alerts
-    live_events = pd.DataFrame(call_api(api_client.get_unacknowledged_events, user_credentials)())[-5:]
+    # Fetch unacknowledged events and associated alerts (up to 15 per events_
+    live_events = pd.DataFrame(call_api(api_client.get_unacknowledged_events, user_credentials)())
 
     # If there is no event, we prevent the callback from updating anything
     if len(live_events) == 0:

--- a/app/main.py
+++ b/app/main.py
@@ -55,8 +55,8 @@ from pages.minimal import (
     build_alert_detected_screen,
     build_no_alert_detected_screen,
 )
-from services import api_client
-from utils._utils import call_api, choose_layer_style
+from services import api_client, call_api
+from utils._utils import choose_layer_style
 from utils.alerts import (
     build_alert_overview,
     build_alerts_elements,

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,3 +1,3 @@
-from .api import api_client
+from .api import api_client, call_api
 
-__all__ = ["api_client"]
+__all__ = ["api_client", "call_api"]

--- a/app/services/api.py
+++ b/app/services/api.py
@@ -3,14 +3,48 @@
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
+from functools import wraps
+from typing import Callable, Dict
+
 from pyroclient import Client
 
 import config as cfg
 
-__all__ = ["api_client"]
+__all__ = ["api_client", "call_api"]
 
 
 if any(not isinstance(val, str) for val in [cfg.API_URL, cfg.API_LOGIN, cfg.API_PWD]):
     raise ValueError("The following environment variables need to be set: 'API_URL', 'API_LOGIN', 'API_PWD'")
 
 api_client = Client(cfg.API_URL, cfg.API_LOGIN, cfg.API_PWD)
+
+
+def call_api(func: Callable, user_credentials: Dict[str, str]) -> Callable:
+    """Decorator to call API method and renew the token if needed. Usage:
+
+     result = call_api(my_func, user_credentials)(1, 2, verify=False)
+
+    Instead of:
+
+    response = my_func(1, verify=False)
+    if response.status_code == 401:
+        api_client.refresh_token(user_credentials["username"], user_credentials["password"])
+    response = my_func(1, verify=False)
+    result = response.json()
+
+    Args:
+        func: function that calls API method
+
+    Returns: decorated function, to be called with positional and keyword arguments
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        response = func(*args, **kwargs)
+        if response.status_code == 401:
+            api_client.refresh_token(user_credentials["username"], user_credentials["password"])
+            response = func(*args, **kwargs)
+        assert response.status_code // 100 == 2, response.text
+        return response.json()
+
+    return wrapper

--- a/app/utils/_utils.py
+++ b/app/utils/_utils.py
@@ -18,16 +18,12 @@ NB: some sections and/or functions still have to be completed, especially API ca
 """
 
 from datetime import datetime
-from functools import wraps
 from pathlib import Path
-from typing import Callable, Dict
 
 import dash_bootstrap_components as dbc
 import dash_html_components as html
 import dash_leaflet as dl
 import pandas as pd
-
-from app.services import api_client
 
 # ----------------------------------------------------------------------------------------------------------------------
 # CONTENT
@@ -244,34 +240,3 @@ def build_historic_markers(dpt_code=None):
 
     # We gather all markers stored in the fire_markers list in a dl.LayerGroup object, which is returned
     return dl.LayerGroup(children=fire_markers, id="historic_fires_markers")
-
-
-def call_api(func: Callable, user_credentials: Dict[str, str]) -> Callable:
-    """Decorator to call API method and renew the token if needed. Usage:
-
-     result = call_api(my_func, user_credentials)(1, 2, verify=False)
-
-    Instead of:
-
-    response = my_func(1, verify=False)
-    if response.status_code == 401:
-        api_client.refresh_token(user_credentials["username"], user_credentials["password"])
-    response = my_func(1, verify=False)
-    result = response.json()
-
-    Args:
-        func: function that calls API method
-
-    Returns: decorated function, to be called with positional and keyword arguments
-    """
-
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        response = func(*args, **kwargs)
-        if response.status_code == 401:
-            api_client.refresh_token(user_credentials["username"], user_credentials["password"])
-            response = func(*args, **kwargs)
-        assert response.status_code // 100 == 2, response.text
-        return response.json()
-
-    return wrapper

--- a/app/utils/_utils.py
+++ b/app/utils/_utils.py
@@ -18,12 +18,16 @@ NB: some sections and/or functions still have to be completed, especially API ca
 """
 
 from datetime import datetime
+from functools import wraps
 from pathlib import Path
+from typing import Callable, Dict
 
 import dash_bootstrap_components as dbc
 import dash_html_components as html
 import dash_leaflet as dl
 import pandas as pd
+
+from app.services import api_client
 
 # ----------------------------------------------------------------------------------------------------------------------
 # CONTENT
@@ -240,3 +244,34 @@ def build_historic_markers(dpt_code=None):
 
     # We gather all markers stored in the fire_markers list in a dl.LayerGroup object, which is returned
     return dl.LayerGroup(children=fire_markers, id="historic_fires_markers")
+
+
+def call_api(func: Callable, user_credentials: Dict[str, str]) -> Callable:
+    """Decorator to call API method and renew the token if needed. Usage:
+
+     result = call_api(my_func, user_credentials)(1, 2, verify=False)
+
+    Instead of:
+
+    response = my_func(1, verify=False)
+    if response.status_code == 401:
+        api_client.refresh_token(user_credentials["username"], user_credentials["password"])
+    response = my_func(1, verify=False)
+    result = response.json()
+
+    Args:
+        func: function that calls API method
+
+    Returns: decorated function, to be called with positional and keyword arguments
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        response = func(*args, **kwargs)
+        if response.status_code == 401:
+            api_client.refresh_token(user_credentials["username"], user_credentials["password"])
+            response = func(*args, **kwargs)
+        assert response.status_code // 100 == 2, response.text
+        return response.json()
+
+    return wrapper


### PR DESCRIPTION
Following https://github.com/pyronear/pyro-api/pull/268, this PR fixes the retrieval of alerts by fetching the alerts associated with unacknowledged events.  In addition:

- increase the number of maximum events from 5 to 10
- add `call_api` method and use to avoid code repetition
- protection against undefined variables (`raise ValueError`)