### PR TITLE
use double digits

### DIFF
--- a/app/utils/alerts.py
+++ b/app/utils/alerts.py
@@ -506,7 +506,7 @@ def build_individual_alert_components(live_alerts, alert_frame_urls, site_device
                         html.Span("Lat : {} / Lon : {}".format(alert_lat, alert_lon), style={"display": "block"}),
                         html.Span(f"Tour : {site_name}", style={"display": "block"}),
                         html.Span(
-                            "{} / {}:{}".format(alert_date, alert_time.hour, alert_time.minute),
+                            "{} / {}:{}".format(alert_date, f"{alert_time.hour:02}", f"{alert_time.minute:02}"),
                             style={"display": "block"},
                         ),
                     ],


### PR DESCRIPTION
Let's use double digit for time, 14:9 doesn't seems right


![Screenshot from 2023-08-26 16-57-12](https://github.com/pyronear/pyro-platform/assets/17944639/0c1432be-da84-4495-9656-dfd818870962)
