### PR TITLE
display alerts from today

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -403,7 +403,6 @@ def update_live_alerts_data(
                 # selection area, etc)
 
                 if condition:
-
                     # We update all outputs
                     return [
                         live_alerts.to_json(orient="records"),

--- a/app/utils/alerts.py
+++ b/app/utils/alerts.py
@@ -289,7 +289,7 @@ def build_alerts_elements(images_url_live_alerts, live_alerts, map_style):
 
     # Building the alerts notification btn
     today = pd.Timestamp.now().normalize()
-    today_alerts_df = all_events[all_events["created_at"] >= today]
+    today_alerts_df = all_events[all_events["created_at"].dt.normalize() == today]
 
     # The rest of the code remains the same...
     nb_today_alerts = len(today_alerts_df)  # Number of unique events from today


### PR DESCRIPTION
As requested by several users, I propose to display only the current day's alerts, as the previous days are useless for firefighters.

There are two options for accessing the history:
A dashboard page with history stats and access to images. 
The ability to specify a date range for alerts to be displayed.

In my opinion, the dashboard is the best option, let's just do it in another PR.

The PR is relatively simple: I filter the days that are not equal to today.

I fixed a small error with filtered_df at the same time
