### PR TITLE
remove acknowledged alerts

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -354,8 +354,8 @@ def update_live_alerts_data(
 
                 if len(live_alerts) < len(ongoing_live_alerts):  # alerts have been acknowledged
                     dict_images_url_live_alerts = ongoing_frame_urls.copy()
-                    for id in ongoing_frame_urls.keys():
-                        if not int(id) in list(live_events["id"]):
+                    for event_id in ongoing_frame_urls.keys():
+                        if not int(event_id) in list(live_events["id"]):
                             del dict_images_url_live_alerts[id]
 
                     new_loaded_frames = list(live_alerts["id"].unique())

--- a/app/main.py
+++ b/app/main.py
@@ -428,9 +428,9 @@ def update_live_alerts_data(
                     else:
                         condition = (~new_alerts["event_id"].isin(ongoing_live_alerts["event_id"].unique())).sum() > 0
 
-                    # If this condition is verified, this means that there is a new "alert" (in fact an event) to display
-                    # on the platform and we therefore need to update all components (the live_alert_header_btn, the user
-                    # selection area, etc)
+                    # If this condition is verified, this means that there is a new "alert" (in fact an event) to
+                    # display on the platform and we therefore need to update all components (the live_alert_header_btn,
+                    #  the user selection area, etc)
 
                     if condition:
                         # We update all outputs
@@ -442,11 +442,13 @@ def update_live_alerts_data(
                             sites_with_live_alerts,
                         ]
 
-                    # If the condition is not verified, we have no new "alert" / event to display on the platform but only
-                    # new detection frames for an existing alert; this means that we do not have to update all components
+                    # If the condition is not verified, we have no new "alert" / event to display on the platform but
+                    # only new detection frames for an existing alert; this means that we do not have to update all
+                    # components
                     else:
-                        # We would like to only update the list of alert frames being displayed and not all the components
-                        # To keep track of the frame URLs that have been loaded, we also update the list of loaded alert IDs
+                        # We would like to only update the list of alert frames being displayed and not all the
+                        # components. To keep track of the frame URLs that have been loaded, we also update the
+                        # list of loaded alert IDs
                         return [
                             dash.no_update,
                             dict_images_url_live_alerts,

--- a/app/main.py
+++ b/app/main.py
@@ -356,7 +356,7 @@ def update_live_alerts_data(
                     dict_images_url_live_alerts = ongoing_frame_urls.copy()
                     for event_id in ongoing_frame_urls.keys():
                         if not int(event_id) in list(live_events["id"]):
-                            del dict_images_url_live_alerts[id]
+                            del dict_images_url_live_alerts[event_id]
 
                     new_loaded_frames = list(live_alerts["id"].unique())
 


### PR DESCRIPTION
Firefighters have told us that a alert remains on the platfrom even after it has been acknowledged.

I've now identified the problem and fixed it.

In update_live_alerts_data we only take into account the case where len(live_alerts) > len(ongoing_live_alerts) i.e. we've received new alerts but not the case where alerts have been acknowledged and are therefore no longer in live_alerts since we only fetch unacknowledged events.