### PR TITLE
force alert list update

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -219,7 +219,7 @@ def change_layer_style(n_clicks=None):
         Output("main_api_fetch_interval", "interval"),
         Output("sites_with_live_alerts", "children"),
     ],
-    Input("main_api_fetch_interval", "n_intervals"),
+    [Input({"type": "trigger_component", "index": ALL}, "data"), Input("main_api_fetch_interval", "n_intervals")],
     [
         State("store_live_alerts_data", "data"),
         State("images_url_live_alerts", "data"),
@@ -231,6 +231,7 @@ def change_layer_style(n_clicks=None):
     ],
 )
 def update_live_alerts_data(
+    intermediate_storage_data,
     n_intervals,
     ongoing_live_alerts,
     ongoing_frame_urls,
@@ -999,7 +1000,7 @@ def close_confirmation_modal(n_clicks):
 @app.callback(
     [
         Output({"type": "manage_confirmation_modal_confirmation_button", "index": MATCH}, "children"),
-        Output({"type": "acknowledge_alert_space", "index": MATCH}, "children"),
+        Output({"type": "trigger_component", "index": MATCH}, "data"),
     ],
     Input({"type": "acknowledgement_confirmation_button", "index": MATCH}, "n_clicks"),
     [State("user_headers", "data"), State("user_credentials", "data")],
@@ -1034,7 +1035,7 @@ def confirm_alert_acknowledgement(n_clicks, user_headers, user_credentials):
         user_token = user_headers["Authorization"].split(" ")[1]
         api_client.token = user_token
         call_api(api_client.acknowledge_event, user_credentials)(event_id=int(event_id))
-        return ["close", html.P("Alerte acquittée.")]
+        return ["close", {"type": "trigger_component", "index": event_id}]
 
 
 @app.callback(

--- a/app/utils/alerts.py
+++ b/app/utils/alerts.py
@@ -546,21 +546,17 @@ def build_individual_alert_components(live_alerts, alert_frame_urls, site_device
 
 
 def build_alert_overview(live_alerts, frame_urls, event_id, acknowledged):
-    if not acknowledged:
-        acknowledge_alert_space_children = [
-            dcc.Markdown("---"),
-            html.Div(
-                dbc.Button(
-                    id={"type": "acknowledge_alert_button", "index": event_id},
-                    children="Acquitter l'alerte",
-                    className="btn-layers",
-                    size="sm",
-                )
-            ),
-        ]
-
-    else:
-        acknowledge_alert_space_children = [html.P("Alerte acquittée.")]
+    acknowledge_alert_space_children = [
+        dcc.Markdown("---"),
+        html.Div(
+            dbc.Button(
+                id={"type": "acknowledge_alert_button", "index": event_id},
+                children="Acquitter l'alerte",
+                className="btn-layers",
+                size="sm",
+            )
+        ),
+    ]
 
     df = pd.read_json(live_alerts)
     df = df.drop_duplicates(["id", "event_id"]).groupby("event_id").head(1)  # Get unique events
@@ -576,6 +572,8 @@ def build_alert_overview(live_alerts, frame_urls, event_id, acknowledged):
         lon = None  # or any default value
 
     alert_azimuth = df[df["event_id"] == event_id]["azimuth"].iloc[0]
+
+    trigger_component = dcc.Store(id={"type": "trigger_component", "index": event_id})
 
     div = html.Div(
         id={"type": "alert_overview", "index": event_id},
@@ -639,6 +637,7 @@ def build_alert_overview(live_alerts, frame_urls, event_id, acknowledged):
                         id={"type": "manage_confirmation_modal_confirmation_button", "index": event_id},
                         style={"display": "none"},
                     ),
+                    trigger_component,
                 ]
             )
         ],


### PR DESCRIPTION
Before the PR #113, the alert list was not updated correctly, so this problem was not visible. When an alert is acknowledged, it's essential to update the alert list, otherwise you'll be trying to access components that no longer exist