### PR TITLE
feat: updated dockerfile to perform poetry installation + requirements automatically

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,25 @@
 FROM python:3.9-slim
 
-# set work directory
-WORKDIR /usr/src/app
-
 # set environment variables
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
-# copy requirements file
-COPY ./requirements.txt /usr/src/app/requirements.txt
+# copy pyproject file to generate requirements.txt
+ADD ./pyproject.toml /tmp/pyproject.toml
 
 # install dependencies
+WORKDIR /tmp
 RUN apt update \
     && apt install git -y \
     && pip install --upgrade pip setuptools wheel \
-    && pip install -r /usr/src/app/requirements.txt \
+    && pip install  --root-user-action ignore poetry \
+    && poetry export -f requirements.txt --without-hashes --output ./requirements.txt \
+    && pip install -r ./requirements.txt \
     && rm -rf /root/.cache/pip \
     && apt purge git -y
 
 # copy project
-COPY app/ /usr/src/app/
+ADD app/ /usr/src/app/
 
+WORKDIR /usr/src/app
 CMD python index.py --host 0.0.0.0 --port 8050


### PR DESCRIPTION
The previous version implied to already have a python + poetry installed on the host machine. Which was not very "dockery". I moved the required steps to install all of it in the dockerfile. 