### PR TITLE
Instantiate `n_click` of acknowledge button to 0 instead of 1

### DIFF
--- a/app/pages/homepage.py
+++ b/app/pages/homepage.py
@@ -115,7 +115,7 @@ def homepage_layout(user_headers, user_credentials):
                                         dbc.Button(
                                             "Acquitter l'alerte",
                                             id="acknowledge-button",
-                                            n_clicks=1,
+                                            n_clicks=0,
                                             className="btn-uniform common-style",
                                             style={"backgroundColor": "#054546"},
                                         ),


### PR DESCRIPTION
### WHAT'S THE ISSUE

Before this PR we have:

https://github.com/pyronear/pyro-platform/blob/68a6bce41277fd806fd9b90030ca86f5cde4b3fe/app/pages/homepage.py#L115-L118

but 

https://github.com/pyronear/pyro-platform/blob/68a6bce41277fd806fd9b90030ca86f5cde4b3fe/app/callbacks/display_callbacks.py#L470-L494

The intention behind `n_clicks == 0` => `PreventUpdate` seems to be making sure that an alert is not acknowledged when the app loads. But that cannot work given that `"acknowledge-button"` is instantiated to have `n_clicks = 1`.

### WHY DOES IT MATTER IF WE HAVE  `prevent_initial_call=True` anyways?

Preventing acknowledgment on load is indeed already covered by `prevent_initial_call=True`.

However, `prevent_initial_call=True` does not cover accidental runs on _redirect_. 

We have:

https://github.com/pyronear/pyro-platform/blob/68a6bce41277fd806fd9b90030ca86f5cde4b3fe/app/layouts/main_layout.py#L31

which implies upon url redirects Dash (/the underlying React engine) attempts to catch redirects triggered within the app and modify pages minimally instead of fully reloading a page.

As I understand the Dash/React lifecycle, this implies _redirects_ triggered within the app do not count as page reloads =>`prevent_initial_call=True` does not apply to those page reloads 
=> Dash re-runs all callbacks (or at least those for which the inputs or states may have changed).
=> At least if the acknowledge button is modified by the redirect (e.g., text translated from https://github.com/pyronear/pyro-platform/pull/173), it's reinstantiated to `n_clicks = 1`, the safeguard in the callback does not apply, and the error is acknowledged.










