### PR TITLE
fix: Corrected typo in confirmation modal

### DIFF
--- a/app/layouts/main_layout.py
+++ b/app/layouts/main_layout.py
@@ -88,7 +88,7 @@ def get_main_layout():
                     html.Div(
                         [
                             html.H4(
-                                "Est-ce une fumée suspecte ? ",
+                                "Est-ce une fumée suspecte ?",
                                 style={
                                     "margin-bottom": "20px",
                                     "font-size": "20px",
@@ -112,7 +112,7 @@ def get_main_layout():
                                         },
                                     ),
                                     html.Button(
-                                        "No, c'est un faux positif",
+                                        "Non, c'est un faux positif",
                                         id="confirm-non-wildfire",
                                         n_clicks=0,
                                         style={
@@ -126,7 +126,7 @@ def get_main_layout():
                                         },
                                     ),
                                     html.Button(
-                                        "Cancel",
+                                        "Annuler",
                                         id="cancel-confirmation",
                                         n_clicks=0,
                                         style={


### PR DESCRIPTION
Small PR to fix text in confirmation modal. There were some typos. 

Alos, in the near future, we'll need to manage the translation of this panel/modal properly & I wonder if the code for this panel/modal shouldn't be located elsewhere in the repo