### PR TITLE
Bug : Fix local timezone display

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+contact@pyronear.org.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/app/callbacks/display_callbacks.py
+++ b/app/callbacks/display_callbacks.py
@@ -16,7 +16,7 @@ from main import app
 
 import config as cfg
 from services import api_client
-from utils.display import build_vision_polygon, create_event_list_from_alerts
+from utils.display import build_vision_polygon, convert_dt_to_local_tz, create_event_list_from_alerts
 
 logger = logging_config.configure_logging(cfg.DEBUG, cfg.SENTRY_DSN)
 
@@ -374,7 +374,7 @@ def update_map_and_alert_info(sequence_on_display, cameras):
             bboxes=row_with_bboxes["processed_bboxes"],
         )
 
-        date_val = row_with_bboxes["created_at"].strftime("%Y-%m-%d %H:%M")
+        date_val = convert_dt_to_local_tz(lat, lon, row_with_bboxes["created_at"])
         cam_name = f"{row_cam['name'].values.item()[:-3].replace('_', ' ')} : {int(row_with_bboxes['azimuth'])}°"
 
         camera_info = f"{cam_name}"

--- a/app/utils/data.py
+++ b/app/utils/data.py
@@ -4,35 +4,9 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
 import ast
-from datetime import datetime
 from typing import List
 
 import pandas as pd
-import pytz
-from timezonefinder import TimezoneFinder
-
-tf = TimezoneFinder()
-
-
-def convert_time(df):
-    df_ts_local = []
-    for _, row in df.iterrows():
-        lat = round(row["lat"], 4)
-        lon = round(row["lon"], 4)
-
-        # Convert created_at to a timezone-aware datetime object assuming it's in UTC
-        alert_ts_utc = datetime.fromisoformat(str(row["created_at"])).replace(tzinfo=pytz.utc)
-
-        # Find the timezone for the alert location
-        timezone_str = tf.timezone_at(lat=lat, lng=lon)
-        if timezone_str is None:  # If the timezone is not found, handle it appropriately
-            timezone_str = "UTC"  # Fallback to UTC or some default
-        alert_timezone = pytz.timezone(timezone_str)
-
-        # Convert alert_ts_utc to the local timezone of the alert
-        df_ts_local.append(alert_ts_utc.astimezone(alert_timezone).strftime("%Y-%m-%dT%H:%M:%S"))
-
-    return df_ts_local
 
 
 def process_bbox(input_str):

--- a/app/utils/display.py
+++ b/app/utils/display.py
@@ -232,7 +232,13 @@ def create_event_list_from_alerts(api_events, cameras):
                     ),
                     style={"fontWeight": "bold"},
                 ),
-                html.Div(event["started_at"].strftime("%Y-%m-%d %H:%M")),
+                html.Div(
+                    convert_dt_to_local_tz(
+                        lat=cameras[cameras["id"] == event["camera_id"]]["lat"].values[0],
+                        lon=cameras[cameras["id"] == event["camera_id"]]["lon"].values[0],
+                        str_utc_timestamp=event["started_at"],
+                    )
+                ),
             ],
             n_clicks=0,
             className="alert-card",

--- a/app/utils/display.py
+++ b/app/utils/display.py
@@ -4,18 +4,59 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
 
+from datetime import datetime
 from io import StringIO
 
 import dash_leaflet as dl
 import pandas as pd
+import pytz
 import requests
 from dash import html
 from geopy import Point
 from geopy.distance import geodesic
+from timezonefinder import TimezoneFinder
 
 import config as cfg
 
 DEPARTMENTS = requests.get(cfg.GEOJSON_FILE, timeout=10).json()
+
+
+tf = TimezoneFinder()
+
+
+def convert_dt_to_local_tz(lat, lon, str_utc_timestamp):
+    """
+    Convert a UTC timestamp string to a local timezone string based on latitude and longitude.
+
+    Parameters:
+    lat (float): Latitude of the location.
+    lon (float): Longitude of the location.
+    str_utc_timestamp (str): UTC timestamp string in ISO 8601 format (e.g., "2023-10-01T12:34:56").
+
+    Returns:
+    str: Local timezone string in the format "%Y-%m-%d %H:%M" or None if the input timestamp is invalid.
+
+    Example:
+    >>> convert_dt_to_local_tz(48.8566, 2.3522, "2023-10-01T12:34:56")
+    '2023-10-01 14:34'
+    """
+    lat = round(lat, 4)
+    lon = round(lon, 4)
+
+    # Convert str_utc_timestamp to a timezone-aware datetime object assuming it's in UTC
+    try:
+        ts_utc = datetime.fromisoformat(str(str_utc_timestamp)).replace(tzinfo=pytz.utc)
+    except ValueError:
+        return None  # Handle invalid datetime format
+
+    # Find the local timezone
+    timezone_str = tf.timezone_at(lat=lat, lng=lon)
+    if timezone_str is None:  # If the timezone is not found, handle it appropriately
+        timezone_str = "UTC"  # Fallback to UTC
+    timezone = pytz.timezone(timezone_str)
+
+    # Convert ts_utc to the local timezone
+    return ts_utc.astimezone(timezone).strftime("%Y-%m-%d %H:%M")
 
 
 def build_departments_geojson():


### PR DESCRIPTION
With the migration to the new data model, a regression has been introduced in the display of times. 

Times are now displayed in UTC, whereas the expected behaviour is to display them according to the camera's time zone. 
(We could discuss having a display relative to the location of the cameras rather than the user, but this is not currently a problem).

This PR fixes this bug. 

It introduces the following modifications : 
- Removed unused and outdated datetime conversion function
- Added conversion function to display utils
- Added datetime conversion when displayed

Happy to discuss it