### PR TITLE
Add live stream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,7 @@ jobs:
           API_LOGIN: ${{ secrets.API_LOGIN }}
           API_PWD: ${{ secrets.API_PWD }}
         run: |
+          touch available_stream.json
           docker network create web || true
           docker compose up -d --build --wait
           echo "Waiting for app..."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
           API_LOGIN: ${{ secrets.API_LOGIN }}
           API_PWD: ${{ secrets.API_PWD }}
         run: |
-          touch available_stream.json
+          echo '{}' > available_stream.json
           docker network create web || true
           docker compose up -d --build --wait
           echo "Waiting for app..."

--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,4 @@ poetry.lock
 
 #project files
 site_devices.json
+available_stream.json

--- a/app/callbacks/data_callbacks.py
+++ b/app/callbacks/data_callbacks.py
@@ -25,6 +25,7 @@ logger = logging_config.configure_logging(cfg.DEBUG, cfg.SENTRY_DSN)
 @app.callback(
     [
         Output("user_token", "data"),
+        Output("user_name", "data"),
         Output("form_feedback_area", "children"),
         Output("username_input", "style"),
         Output("password_input", "style"),
@@ -79,6 +80,7 @@ def login_callback(n_clicks, username, password, user_token, lang):
         return (
             dash.no_update,
             dash.no_update,
+            dash.no_update,
             input_style_unchanged,
             input_style_unchanged,
             empty_style_unchanged,
@@ -99,6 +101,7 @@ def login_callback(n_clicks, username, password, user_token, lang):
             # The login modal remains open; other outputs are updated with arbitrary values
             return (
                 dash.no_update,
+                dash.no_update,
                 form_feedback,
                 input_style_unchanged,
                 input_style_unchanged,
@@ -113,6 +116,7 @@ def login_callback(n_clicks, username, password, user_token, lang):
 
                 return (
                     user_token,
+                    username,
                     dash.no_update,
                     hide_element_style,
                     hide_element_style,
@@ -126,6 +130,7 @@ def login_callback(n_clicks, username, password, user_token, lang):
 
                 return (
                     dash.no_update,
+                    dash.no_update,
                     form_feedback,
                     input_style_unchanged,
                     input_style_unchanged,
@@ -135,6 +140,35 @@ def login_callback(n_clicks, username, password, user_token, lang):
                 )
 
     raise PreventUpdate
+
+
+@app.callback(
+    Output("available-stream", "data"),
+    Input("user_name", "data"),
+)
+def load_available_stream(user_name):
+    print("[load_available_stream] Triggered with user_name:", user_name)
+
+    if not user_name:
+        raise PreventUpdate
+
+    try:
+        with open("available_stream.json", "r") as f:
+            full_data = json.load(f)
+    except FileNotFoundError:
+        print("available_stream.json not found.")
+        raise PreventUpdate
+    
+    print(full_data)
+
+    user_streams = full_data.get(user_name)
+    if not user_streams:
+        print(f"No stream config found for user '{user_name}'")
+        raise PreventUpdate
+    
+    print(user_streams)
+
+    return user_streams  # Example: { "croix-augas": "192.168.1.28", ... }
 
 
 @app.callback(
@@ -149,6 +183,7 @@ def get_cameras(user_token):
     cameras = pd.DataFrame(api_client.fetch_cameras().json())
 
     return cameras.to_json(orient="split")
+
 
 
 @app.callback(

--- a/app/callbacks/data_callbacks.py
+++ b/app/callbacks/data_callbacks.py
@@ -65,8 +65,6 @@ def login_callback(n_clicks, username, password, user_token, lang):
     hide_element_style = {"display": "none"}
     show_spinner_style = {"transform": "scale(4)"}
 
-    print("coucou")
-
     translate = {
         "fr": {
             "missing_password_or_user_name": "Il semble qu'il manque votre nom d'utilisateur et/ou votre mot de passe.",
@@ -145,7 +143,7 @@ def login_callback(n_clicks, username, password, user_token, lang):
 
 
 @app.callback(
-    Output("available-stream", "data"),
+    Output("available-stream-sites", "data"),
     Input("user_name", "data"),
 )
 def load_available_stream(user_name):

--- a/app/callbacks/data_callbacks.py
+++ b/app/callbacks/data_callbacks.py
@@ -11,6 +11,7 @@ import logging_config
 import pandas as pd
 from dash import callback_context, dcc, html
 from dash.dependencies import Input, Output, State
+from dash.development.base_component import Component
 from dash.exceptions import PreventUpdate
 from main import app
 
@@ -90,7 +91,7 @@ def login_callback(n_clicks, username, password, user_token, lang):
 
     if n_clicks:
         # We instantiate the form feedback output
-        form_feedback = [dcc.Markdown("---")]
+        form_feedback: list[Component] = [dcc.Markdown("---")]
         # First check verifies whether both a username and a password have been provided
         if username is None or password is None or len(username) == 0 or len(password) == 0:
             # If either the username or the password is missing, the condition is verified

--- a/app/callbacks/data_callbacks.py
+++ b/app/callbacks/data_callbacks.py
@@ -158,14 +158,14 @@ def load_available_stream(user_name):
     except FileNotFoundError:
         print("available_stream.json not found.")
         raise PreventUpdate
-    
+
     print(full_data)
 
     user_streams = full_data.get(user_name)
     if not user_streams:
         print(f"No stream config found for user '{user_name}'")
         raise PreventUpdate
-    
+
     print(user_streams)
 
     return user_streams  # Example: { "croix-augas": "192.168.1.28", ... }
@@ -183,7 +183,6 @@ def get_cameras(user_token):
     cameras = pd.DataFrame(api_client.fetch_cameras().json())
 
     return cameras.to_json(orient="split")
-
 
 
 @app.callback(

--- a/app/callbacks/data_callbacks.py
+++ b/app/callbacks/data_callbacks.py
@@ -147,8 +147,6 @@ def login_callback(n_clicks, username, password, user_token, lang):
     Input("user_name", "data"),
 )
 def load_available_stream(user_name):
-    print("[load_available_stream] Triggered with user_name:", user_name)
-
     if not user_name:
         raise PreventUpdate
 
@@ -156,17 +154,13 @@ def load_available_stream(user_name):
         with open("available_stream.json", "r") as f:
             full_data = json.load(f)
     except FileNotFoundError:
-        print("available_stream.json not found.")
+        logger.info("available_stream.json not found.")
         raise PreventUpdate
-
-    print(full_data)
 
     user_streams = full_data.get(user_name)
     if not user_streams:
-        print(f"No stream config found for user '{user_name}'")
+        logger.info(f"No stream config found for user '{user_name}'")
         raise PreventUpdate
-
-    print(user_streams)
 
     return user_streams
 

--- a/app/callbacks/data_callbacks.py
+++ b/app/callbacks/data_callbacks.py
@@ -153,9 +153,9 @@ def load_available_stream(user_name):
     try:
         with open("available_stream.json", "r") as f:
             full_data = json.load(f)
-    except FileNotFoundError:
-        logger.info("available_stream.json not found.")
-        raise PreventUpdate
+    except (FileNotFoundError, IsADirectoryError, json.JSONDecodeError):
+        logger.warning("available_stream.json not found or invalid. Using empty dict.")
+        full_data = {}
 
     user_streams = full_data.get(user_name)
     if not user_streams:

--- a/app/callbacks/data_callbacks.py
+++ b/app/callbacks/data_callbacks.py
@@ -65,6 +65,8 @@ def login_callback(n_clicks, username, password, user_token, lang):
     hide_element_style = {"display": "none"}
     show_spinner_style = {"transform": "scale(4)"}
 
+    print("coucou")
+
     translate = {
         "fr": {
             "missing_password_or_user_name": "Il semble qu'il manque votre nom d'utilisateur et/ou votre mot de passe.",
@@ -168,7 +170,7 @@ def load_available_stream(user_name):
 
     print(user_streams)
 
-    return user_streams  # Example: { "croix-augas": "192.168.1.28", ... }
+    return user_streams
 
 
 @app.callback(

--- a/app/callbacks/display_callbacks.py
+++ b/app/callbacks/display_callbacks.py
@@ -660,9 +660,6 @@ def update_datepicker(open_clicks, selected_date):
     return dash.no_update, dash.no_update, dash.no_update, dash.no_update
 
 
-
-
-
 @app.callback(
     Output("selected-camera-info", "data"),
     Input("start-live-stream", "n_clicks"),
@@ -702,5 +699,3 @@ def pick_live_stream_camera(n_clicks, sequence_data, cameras_data):
     print((cam_name, azimuth))
 
     return (cam_name, azimuth)
-
-

--- a/app/callbacks/display_callbacks.py
+++ b/app/callbacks/display_callbacks.py
@@ -60,6 +60,35 @@ def update_blinking_alarm_language(search):
     return [translate[lang]["blinking_alarm"]]
 
 
+import urllib.parse
+
+from dash import Input, Output
+
+import config as cfg
+
+
+@app.callback(Output("home_button_text", "children"), Input("url", "search"))
+def update_home_button_language(search):
+    translate = {
+        "fr": {"home": "Alertes"},
+        "es": {"home": "Alertas"},
+    }
+    params = dict(urllib.parse.parse_qsl(search.lstrip("?"))) if search else {}
+    lang = params.get("lang", cfg.DEFAULT_LANGUAGE)
+    return [translate.get(lang, translate["fr"])["home"]]
+
+
+@app.callback(Output("live_stream_button_text", "children"), Input("url", "search"))
+def update_live_stream_button_language(search):
+    translate = {
+        "fr": {"live_stream": "Levée de doute"},
+        "es": {"live_stream": "Transmisión en Vivo"},
+    }
+    params = dict(urllib.parse.parse_qsl(search.lstrip("?"))) if search else {}
+    lang = params.get("lang", cfg.DEFAULT_LANGUAGE)
+    return [translate.get(lang, translate["fr"])["live_stream"]]
+
+
 @app.callback(Output("url", "search"), [Input("btn-fr", "n_clicks"), Input("btn-es", "n_clicks")])
 def update_language_url(fr_clicks, es_clicks):
     # Check which button has been clicked

--- a/app/callbacks/display_callbacks.py
+++ b/app/callbacks/display_callbacks.py
@@ -6,6 +6,7 @@
 import ast
 import json
 import urllib
+import urllib.parse
 from datetime import date
 from io import StringIO
 
@@ -58,13 +59,6 @@ def update_blinking_alarm_language(search):
     lang = params.get("lang", cfg.DEFAULT_LANGUAGE)
 
     return [translate[lang]["blinking_alarm"]]
-
-
-import urllib.parse
-
-from dash import Input, Output
-
-import config as cfg
 
 
 @app.callback(Output("home_button_text", "children"), Input("url", "search"))

--- a/app/callbacks/display_callbacks.py
+++ b/app/callbacks/display_callbacks.py
@@ -671,11 +671,11 @@ def pick_live_stream_camera(n_clicks, camera_label, azimuth_label):
     if not camera_label or not azimuth_label:
         raise PreventUpdate
     try:
-        cam_name = camera_label.split(" ")[0]
-        corrected_azimuth = int(azimuth_label.replace("°", "").strip())
+        cam_name, _, azimuth_camera = camera_label.split(" ")
+        # detection_azimuth = int(azimuth_label.replace("°", "").strip()) Need azimuth refine first
     except Exception as e:
         logger.warning(f"[pick_live_stream_camera] Failed to parse camera info: {e}")
         raise PreventUpdate
 
-    logger.info(f"Selected camera={cam_name}, azimuth={corrected_azimuth}")
-    return (cam_name, corrected_azimuth)
+    logger.info(f"Selected camera={cam_name}, azimuth={azimuth_camera}")
+    return (cam_name, azimuth_camera)

--- a/app/callbacks/display_callbacks.py
+++ b/app/callbacks/display_callbacks.py
@@ -672,6 +672,7 @@ def pick_live_stream_camera(n_clicks, camera_label, azimuth_label):
         raise PreventUpdate
     try:
         cam_name, _, azimuth_camera = camera_label.split(" ")
+        azimuth_camera = int(azimuth_camera.replace("°",""))
         # detection_azimuth = int(azimuth_label.replace("°", "").strip()) Need azimuth refine first
     except Exception as e:
         logger.warning(f"[pick_live_stream_camera] Failed to parse camera info: {e}")

--- a/app/callbacks/display_callbacks.py
+++ b/app/callbacks/display_callbacks.py
@@ -672,7 +672,7 @@ def pick_live_stream_camera(n_clicks, camera_label, azimuth_label):
         raise PreventUpdate
     try:
         cam_name, _, azimuth_camera = camera_label.split(" ")
-        azimuth_camera = int(azimuth_camera.replace("°",""))
+        azimuth_camera = int(azimuth_camera.replace("°", ""))
         # detection_azimuth = int(azimuth_label.replace("°", "").strip()) Need azimuth refine first
     except Exception as e:
         logger.warning(f"[pick_live_stream_camera] Failed to parse camera info: {e}")

--- a/app/callbacks/live_callbacks.py
+++ b/app/callbacks/live_callbacks.py
@@ -8,6 +8,7 @@ from dash.dependencies import ALL
 from dash.exceptions import PreventUpdate
 from main import app
 
+import config as cfg
 from utils.display import build_vision_polygon
 from utils.live_stream import fetch_cameras, find_closest_camera_pose  # replace with actual import
 
@@ -373,11 +374,10 @@ def get_pi_camera_from_dropdown(site_name, available_stream, camera_info):
 
 @app.callback(
     Output("video-stream", "src"),
-    Input("selected-camera-pose", "data"),
+    Input("available-stream-dropdown", "value"),
 )
-def update_stream_url(camera_pose):
-    if not camera_pose:
+def update_stream_url(site_name):
+    if not site_name:
         raise PreventUpdate
-    ip = camera_pose["ip"]
-    stream_url = f"http://{ip}:8889/stream"  # Adjust if needed
+    stream_url = f"{cfg.MEDIAMTX_SERVER_IP}:8889/{site_name}"
     return stream_url

--- a/app/callbacks/live_callbacks.py
+++ b/app/callbacks/live_callbacks.py
@@ -257,7 +257,7 @@ def control_camera(current_camera, up, down, left, right, stop, zoom_level, move
         # 🔁 Case 1: Triggered by current_camera
         if trigger == "current_camera":
             logger.info(f"[AUTO] Triggered by camera pose change for {camera_ip}")
-            time.sleep(1) # let stream start first
+            time.sleep(1)  # let stream start first
 
             # Move to preset pose if defined
             if pose_id is not None:

--- a/app/callbacks/live_callbacks.py
+++ b/app/callbacks/live_callbacks.py
@@ -412,7 +412,6 @@ def update_cone(camera_name, n_clicks_list, pi_cameras, api_cameras_data):
     site_lat = float(row["lat"].values[0])
     site_lon = float(row["lon"].values[0])
     opening_angle = int(row["angle_of_view"].values[0])
-    dist_km = 10  # Default projection distance
 
     poses = camera_info.get("poses", [])
     azimuths = camera_info.get("azimuths", [])
@@ -433,7 +432,7 @@ def update_cone(camera_name, n_clicks_list, pi_cameras, api_cameras_data):
             site_lon=site_lon,
             azimuth=new_azimuth,
             opening_angle=opening_angle,
-            dist_km=dist_km,
+            dist_km=cfg.CAM_RANGE_KM,
         )
         return [cone]
 

--- a/app/callbacks/live_callbacks.py
+++ b/app/callbacks/live_callbacks.py
@@ -91,7 +91,7 @@ def set_azimuth(pi_cameras, trigered_from_alert, selected_camera_info):
     Output("stream-camera-name", "children"),
     Output("stream-preset-azimuths", "children"),
     Input("stream-current-azimuth", "value"),
-    State("pi_cameras", "data"),
+    Input("pi_cameras", "data"),
     prevent_initial_call=True,
 )
 def set_current_camera(target_azimuth, pi_cameras):
@@ -257,6 +257,7 @@ def control_camera(current_camera, up, down, left, right, stop, zoom_level, move
         # 🔁 Case 1: Triggered by current_camera
         if trigger == "current_camera":
             logger.info(f"[AUTO] Triggered by camera pose change for {camera_ip}")
+            time.sleep(1) # let stream start first
 
             # Move to preset pose if defined
             if pose_id is not None:

--- a/app/callbacks/live_callbacks.py
+++ b/app/callbacks/live_callbacks.py
@@ -7,25 +7,22 @@
 import datetime
 from io import StringIO
 
+import logging_config
 import pandas as pd
 import requests
-from dash import Input, Output, State, callback_context, ctx, exceptions, html, no_update
+from dash import Input, Output, State, ctx, exceptions, html, no_update
 from dash.dependencies import ALL
 from dash.exceptions import PreventUpdate
 from main import app
 
 import config as cfg
 from utils.display import build_vision_polygon
-from utils.live_stream import fetch_cameras, find_closest_camera_pose  # replace with actual import
+from utils.live_stream import fetch_cameras, find_closest_camera_pose, send_api_request
+
+logger = logging_config.configure_logging(cfg.DEBUG, cfg.SENTRY_DSN)
 
 
-# API Communication
-def send_api_request(FASTAPI_URL, endpoint: str):
-    try:
-        response = requests.post(f"{FASTAPI_URL}{endpoint}")
-        return response.json().get("message", "Unknown response")
-    except requests.exceptions.RequestException:
-        return "Error: Could not reach API server."
+start_time = None
 
 
 @app.callback(
@@ -56,19 +53,53 @@ def control_camera(
     move_speed,
     selected_camera,
 ):
-    print("[control_camera] Triggered with args:", locals())
-    ctx = callback_context
+    """
+    Callback to control camera actions (stream, movement, zoom) based on UI input.
+
+    Parameters
+    ----------
+    start_stream : int
+        Click count for start-stream button.
+    stop_stream : int
+        Click count for stop-stream button.
+    up, down, left, right, stop : int
+        Click counts for movement control buttons.
+    zoom_level : float
+        Current zoom level (0-100%).
+    camera_id : str
+        Currently selected camera ID.
+    move_speed : int
+        Speed slider value.
+    selected_camera : dict
+        Selected camera metadata (contains 'camera', 'ip', 'pi_ip', etc.)
+
+    Returns
+    -------
+    no_update
+        Placeholder to satisfy Dash Output without altering the layout.
+    """
+    logger.debug(
+        "[control_camera] Triggered with args: %s",
+        {
+            "start": start_stream,
+            "stop": stop_stream,
+            "zoom": zoom_level,
+            "camera_id": camera_id,
+            "selected_camera": selected_camera,
+        },
+    )
+
     if not ctx.triggered or not selected_camera:
         raise PreventUpdate
 
     button_id = ctx.triggered[0]["prop_id"].split(".")[0]
 
-    if selected_camera["camera"] != camera_id:
+    if selected_camera.get("camera") != camera_id:
         raise PreventUpdate
 
-    # Use the Pi IP instead of the camera IP
     pi_ip = selected_camera.get("pi_ip")
-    if not pi_ip:
+    camera_ip = selected_camera.get("ip")
+    if not pi_ip or not camera_ip:
         raise PreventUpdate
 
     direction_map = {
@@ -79,30 +110,33 @@ def control_camera(
         "stop-move": "Stop",
     }
 
-    if button_id == "start-stream":
-        send_api_request(f"http://{pi_ip}:8081", f"/start_stream/{camera_id}")
+    try:
+        if button_id == "start-stream":
+            send_api_request(f"http://{pi_ip}:8081", f"/start_stream/{camera_ip}")
 
-    elif button_id == "stop-stream":
-        send_api_request(f"http://{pi_ip}:8081", "/stop_stream")
+        elif button_id == "stop-stream":
+            send_api_request(f"http://{pi_ip}:8081", f"/stop_stream/{camera_ip}")
 
-    elif button_id in direction_map:
-        direction = direction_map[button_id]
-        if direction != "Stop":
-            true_speed = int(move_speed / 10) + 1
-            print("mooooove to ", f"http://{pi_ip}:8081", f"/move/{camera_id}?direction={direction}&speed={true_speed}")
-            send_api_request(f"http://{pi_ip}:8081", f"/move/{camera_id}?direction={direction}&speed={true_speed}")
-        else:
-            send_api_request(f"http://{pi_ip}:8081", f"/stop/{camera_id}")
+        elif button_id in direction_map:
+            direction = direction_map[button_id]
+            if direction != "Stop":
+                true_speed = int(move_speed / 10) + 1
+                logger.info("Moving camera %s -> %s at speed %d", camera_ip, direction, true_speed)
+                send_api_request(f"http://{pi_ip}:8081", f"/move/{camera_ip}?direction={direction}&speed={true_speed}")
+            else:
+                logger.info("Stopping movement for camera %s", camera_ip)
+                send_api_request(f"http://{pi_ip}:8081", f"/stop/{camera_ip}")
 
-    elif button_id == "zoom-input":
-        if zoom_level is not None:
-            true_zoom = int(zoom_level * 64 / 100)  # because backend expects 0-64
-            send_api_request(f"http://{pi_ip}:8081", f"/zoom/{camera_id}/{true_zoom}")
+        elif button_id == "zoom-input":
+            if zoom_level is not None:
+                true_zoom = int(zoom_level * 64 / 100)
+                logger.info("Zooming camera %s to level %d", camera_ip, true_zoom)
+                send_api_request(f"http://{pi_ip}:8081", f"/zoom/{camera_ip}/{true_zoom}")
+
+    except Exception as e:
+        logger.warning("Failed to send command to camera %s via Pi %s: %s", camera_ip, pi_ip, e)
 
     return no_update
-
-
-start_time = None
 
 
 @app.callback(
@@ -113,15 +147,30 @@ start_time = None
     prevent_initial_call=True,
 )
 def control_detection(start_clicks, stop_clicks):
-    print("[control_detection] Triggered with args:", locals())
+    """
+    Callback to control the stream timer and detection status.
 
-    triggered = ctx.triggered_id
+    Triggered by clicks on the start or stop stream buttons.
+    Sets a global start time when streaming begins and disables the timer when stopped.
+
+    Returns
+    -------
+    Tuple[bool, str] or Tuple[no_update, no_update]
+        - Whether the timer should be disabled.
+        - The current detection status ("running", "stopped", or no_update).
+    """
     global start_time
+    triggered = ctx.triggered_id
+
+    logger.debug("[control_detection] Triggered by: %s", triggered)
 
     if triggered == "start-stream":
         start_time = datetime.datetime.now()
+        logger.info("Stream started at %s", start_time)
         return False, "running"  # Enable timer
+
     elif triggered == "stop-stream":
+        logger.info("Stream stopped")
         start_time = None
         return True, "stopped"  # Disable timer
 
@@ -135,10 +184,30 @@ def control_detection(start_clicks, stop_clicks):
     prevent_initial_call=True,
 )
 def update_status(n, detection_status):
+    """
+    Callback to update the stream status banner with elapsed time since stream start.
+
+    Triggered periodically by the stream timer. Displays a warning banner if detection is inactive.
+
+    Parameters
+    ----------
+    n : int
+        Number of timer intervals elapsed.
+    detection_status : str
+        Current status of detection ("running", "stopped", etc.).
+
+    Returns
+    -------
+    html.Div or str
+        HTML elements displaying stream status, or empty string if not applicable.
+    """
     if detection_status == "running" and start_time:
         elapsed = datetime.datetime.now() - start_time
         minutes, seconds = divmod(int(elapsed.total_seconds()), 60)
         timer_text = f"{minutes:02d}:{seconds:02d}"
+
+        logger.debug("[update_status] Detection inactive since %s", timer_text)
+
         return html.Div(
             [
                 html.Span(
@@ -152,10 +221,14 @@ def update_status(n, detection_status):
                         "fontWeight": "bold",
                     },
                 ),
-                html.Span(f"Levée de doute en cours, la détection n'est plus active depuis {timer_text}"),
+                html.Span(
+                    f"⚠️ Levée de doute en cours, la détection n'est plus active depuis {timer_text}",
+                    style={"color": "orange", "fontWeight": "bold"},
+                ),
             ]
         )
     else:
+        logger.debug("[update_status] No active stream or start_time missing")
         return ""
 
 
@@ -166,36 +239,56 @@ def update_status(n, detection_status):
     prevent_initial_call=True,
 )
 def update_pose_buttons(camera_name, pi_cameras):
-    print("[update_pose_buttons] Triggered with args:", locals())
+    """
+    Callback to generate pose buttons based on the selected camera.
 
+    Parameters
+    ----------
+    camera_name : str
+        Name of the selected camera.
+    pi_cameras : dict
+        Dictionary of camera configurations retrieved from the Pi.
+
+    Returns
+    -------
+    List[html.Button] or str
+        A list of pose buttons with azimuth labels, or an empty string if camera is not found.
+    """
     if not camera_name or not pi_cameras:
+        logger.debug("[update_pose_buttons] Missing camera name or pi_cameras")
         return ""
 
     camera_info = pi_cameras.get(camera_name)
     if not camera_info:
+        logger.warning("[update_pose_buttons] Camera '%s' not found in pi_cameras", camera_name)
         return ""
 
-    buttons = []
     poses = camera_info.get("poses", [])
     azimuths = camera_info.get("azimuths", [])
 
-    for pose_id, az in zip(poses, azimuths, strict=True):
-        buttons.append(
-            html.Button(
-                f"{az}°",
-                id={"type": "pose-button", "camera": camera_name, "index": pose_id},
-                n_clicks=0,
-                style={
-                    "background": "none",
-                    "border": "2px solid #098386",
-                    "borderRadius": "8px",
-                    "fontSize": "16px",
-                    "cursor": "pointer",
-                    "padding": "6px 12px",
-                    "color": "#098386",
-                },
-            )
+    if len(poses) != len(azimuths):
+        logger.warning("[update_pose_buttons] Mismatched poses and azimuths for camera '%s'", camera_name)
+        return ""
+
+    logger.debug("[update_pose_buttons] Generating %d pose buttons for camera '%s'", len(poses), camera_name)
+
+    buttons = [
+        html.Button(
+            f"{az}°",
+            id={"type": "pose-button", "camera": camera_name, "index": pose_id},
+            n_clicks=0,
+            style={
+                "background": "none",
+                "border": "2px solid #098386",
+                "borderRadius": "8px",
+                "fontSize": "16px",
+                "cursor": "pointer",
+                "padding": "6px 12px",
+                "color": "#098386",
+            },
         )
+        for pose_id, az in zip(poses, azimuths, strict=True)
+    ]
 
     return buttons
 
@@ -209,36 +302,58 @@ def update_pose_buttons(camera_name, pi_cameras):
     prevent_initial_call=True,
 )
 def move_to_pose(n_clicks_list, camera_name, pi_cameras, site_name, available_stream):
-    print("[move_to_pose] Triggered with args:", locals())
+    """
+    Callback to move a camera to a specific pose when a pose button is clicked.
 
+    Parameters
+    ----------
+    n_clicks_list : List[int]
+        List of click counts for each pose button.
+    camera_name : str
+        Name of the selected camera.
+    pi_cameras : dict
+        Camera data including IP and pose info.
+    site_name : str
+        Selected site for streaming.
+    available_stream : dict
+        Mapping from site names to their associated Pi IPs.
+
+    Returns
+    -------
+    None
+        This callback has no output; it sends a request to move the camera.
+    """
     triggered = ctx.triggered_id
 
     if not triggered or not pi_cameras or not camera_name:
+        logger.debug("[move_to_pose] No valid trigger or data missing")
         raise PreventUpdate
 
-    triggered_camera = triggered["camera"]
-    pose_id = triggered["index"]
+    triggered_camera = triggered.get("camera")
+    pose_id = triggered.get("index")
 
     if triggered_camera != camera_name:
+        logger.debug("[move_to_pose] Triggered camera '%s' != selected camera '%s'", triggered_camera, camera_name)
         raise PreventUpdate
 
     camera_info = pi_cameras.get(camera_name)
     if not camera_info:
+        logger.warning("[move_to_pose] Camera info not found for '%s'", camera_name)
         raise PreventUpdate
 
-    camera_ip = camera_info["ip"]
+    camera_ip = camera_info.get("ip")
     pi_ip = available_stream.get(site_name)
-    if not pi_ip:
-        print(f"No Pi IP found for {site_name}")
+    if not pi_ip or not camera_ip:
+        logger.warning("[move_to_pose] Missing IP for site '%s' or camera '%s'", site_name, camera_name)
         raise PreventUpdate
 
     pi_api_url = f"http://{pi_ip}:8081"
 
     try:
         response = requests.post(f"{pi_api_url}/move/{camera_ip}?pose_id={pose_id}&speed=50")
-        print("Move to pose response:", response.json())
+        logger.info("[move_to_pose] Moved camera '%s' to pose '%s': %s", camera_name, pose_id, response.json())
     except Exception as e:
-        print(f"Move to pose error: {e}")
+        logger.error("[move_to_pose] Error moving camera '%s' to pose '%s': %s", camera_name, pose_id, e)
         raise PreventUpdate
 
 
@@ -251,44 +366,68 @@ def move_to_pose(n_clicks_list, camera_name, pi_cameras, site_name, available_st
     prevent_initial_call=True,
 )
 def update_cone(camera_name, n_clicks_list, pi_cameras, api_cameras_data):
-    print("[update_cone] Triggered with args:", locals())
+    """
+    Callback to update the camera vision cone overlay when the camera or pose changes.
+
+    Parameters
+    ----------
+    camera_name : str
+        Selected camera name.
+    n_clicks_list : List[int]
+        List of click counts from pose buttons.
+    pi_cameras : dict
+        Local camera configuration data (IP, azimuths, poses, etc.).
+    api_cameras_data : str
+        JSON string of camera metadata from the API (e.g. location, opening angle).
+
+    Returns
+    -------
+    List[Component] or no_update
+        The vision cone polygon overlay, or no update if conditions are invalid.
+    """
+    logger.debug("[update_cone] Triggered with camera_name='%s'", camera_name)
 
     triggered = ctx.triggered_id
 
     if not triggered or not camera_name or not pi_cameras or not api_cameras_data:
+        logger.debug("[update_cone] Missing required data")
         raise PreventUpdate
 
     camera_info = pi_cameras.get(camera_name)
     if not camera_info:
+        logger.warning("[update_cone] Camera '%s' not found in pi_cameras", camera_name)
         raise PreventUpdate
 
-    # Load full camera metadata
-    df_cams = pd.read_json(StringIO(api_cameras_data), orient="split")
-    row = df_cams[df_cams["name"] == camera_name]
+    try:
+        df_cams = pd.read_json(StringIO(api_cameras_data), orient="split")
+        row = df_cams[df_cams["name"] == camera_name]
+    except Exception as e:
+        logger.error("[update_cone] Failed to parse API camera data: %s", e)
+        raise PreventUpdate
 
     if row.empty:
-        print(f"[update_cone] Camera {camera_name} not found in metadata.")
+        logger.warning("[update_cone] Camera '%s' not found in API metadata", camera_name)
         raise PreventUpdate
 
     site_lat = float(row["lat"].values[0])
     site_lon = float(row["lon"].values[0])
     opening_angle = int(row["angle_of_view"].values[0])
-    dist_km = 10  # If you want to replace this, extract it from elsewhere or make it a constant
+    dist_km = 10  # Default projection distance
 
     poses = camera_info.get("poses", [])
     azimuths = camera_info.get("azimuths", [])
 
     try:
-        # Case 1: Camera selection
+        # Case 1: camera just selected
         if triggered == "camera-select":
             pose_index = 0
-
-        # Case 2: Pose button click
         else:
             pose_id = int(triggered["index"])
             pose_index = poses.index(pose_id)
 
         new_azimuth = azimuths[pose_index]
+        logger.info("[update_cone] Building cone for camera='%s' at azimuth=%d°", camera_name, new_azimuth)
+
         cone, _ = build_vision_polygon(
             site_lat=site_lat,
             site_lon=site_lon,
@@ -299,7 +438,7 @@ def update_cone(camera_name, n_clicks_list, pi_cameras, api_cameras_data):
         return [cone]
 
     except Exception as e:
-        print(f"Error building vision cone: {e}")
+        logger.error("[update_cone] Error building vision cone: %s", e)
         return no_update
 
 
@@ -310,7 +449,24 @@ def update_cone(camera_name, n_clicks_list, pi_cameras, api_cameras_data):
     prevent_initial_call=True,
 )
 def sync_dropdown_from_camera_info(camera_info, available_stream):
-    print("[sync_dropdown_from_camera_info] Triggered with:", camera_info)
+    """
+    Callback to synchronize the stream dropdown value based on the selected camera info.
+
+    Extracts the site name from the selected camera and updates the dropdown if valid.
+
+    Parameters
+    ----------
+    camera_info : Tuple[str, int]
+        Selected camera name and azimuth from the UI.
+    available_stream : dict
+        Mapping of site names to their associated Pi IPs.
+
+    Returns
+    -------
+    str or PreventUpdate
+        The site name to set in the dropdown, or prevent update if not found.
+    """
+    logger.debug("[sync_dropdown_from_camera_info] Triggered with: %s", camera_info)
 
     if not camera_info or not available_stream:
         raise exceptions.PreventUpdate
@@ -318,12 +474,13 @@ def sync_dropdown_from_camera_info(camera_info, available_stream):
     cam_name, _ = camera_info
     site_name = cam_name[:-3].strip().lower()
 
-    print("!!!!!! sync_dropdown_from_camera_info", site_name, available_stream)
+    logger.debug("[sync_dropdown_from_camera_info] Extracted site_name='%s'", site_name)
 
     if site_name not in available_stream:
-        print(f"[sync_dropdown_from_camera_info] '{site_name}' not in available_stream")
+        logger.warning("[sync_dropdown_from_camera_info] Site '%s' not in available_stream", site_name)
         raise exceptions.PreventUpdate
 
+    logger.info("[sync_dropdown_from_camera_info] Setting stream dropdown to '%s'", site_name)
     return site_name
 
 
@@ -338,27 +495,47 @@ def sync_dropdown_from_camera_info(camera_info, available_stream):
     prevent_initial_call=True,
 )
 def get_pi_camera_from_dropdown(site_name, available_stream, camera_info):
-    print("[get_pi_camera_from_dropdown] Triggered with:", site_name)
+    """
+    Callback to retrieve Pi camera info and set the default pose and camera selection.
+
+    Parameters
+    ----------
+    site_name : str
+        Selected site from the dropdown.
+    available_stream : dict
+        Mapping from site name to Pi IP.
+    camera_info : Tuple[str, int] or None
+        Previously selected camera and azimuth (optional).
+
+    Returns
+    -------
+    Tuple[dict, dict, List[dict], str]
+        - Pose data with pi_ip,
+        - All cameras retrieved from the Pi,
+        - Options for camera dropdown,
+        - Default selected camera name.
+    """
+    logger.debug("[get_pi_camera_from_dropdown] Triggered with site: %s", site_name)
 
     if not site_name or not available_stream:
         raise PreventUpdate
 
     pi_ip = available_stream.get(site_name)
     if not pi_ip:
-        print(f"No Pi IP found for {site_name}")
+        logger.warning("No Pi IP found for site '%s'", site_name)
         raise PreventUpdate
 
     pi_api_url = f"http://{pi_ip}:8081"
-    print(f"Querying Pi at: {pi_api_url}")
+    logger.info("Querying Pi at: %s", pi_api_url)
 
     try:
         pi_cameras = fetch_cameras(pi_api_url)
     except Exception as e:
-        print(f"Error fetching cameras from {pi_api_url}: {e}")
+        logger.error("Error fetching cameras from %s: %s", pi_api_url, e)
         raise PreventUpdate
 
     if not pi_cameras:
-        print("No cameras found")
+        logger.warning("No cameras found on Pi at site '%s'", site_name)
         raise PreventUpdate
 
     first_cam_name = next(iter(pi_cameras.keys()))
@@ -367,20 +544,19 @@ def get_pi_camera_from_dropdown(site_name, available_stream, camera_info):
     poses = cam_info.get("poses", [])
 
     if not azimuths or not poses:
-        print("Camera has no pose or azimuth info")
+        logger.warning("Camera '%s' has no pose or azimuth info", first_cam_name)
         raise PreventUpdate
 
-    # Use azimuth from selected-camera-info, fallback to azimuth[0]
     target_azimuth = camera_info[1] if camera_info else azimuths[0]
 
     try:
         pose = find_closest_camera_pose(target_azimuth, pi_cameras)
     except Exception as e:
-        print(f"Error finding closest camera pose: {e}")
+        logger.error("Error finding closest camera pose: %s", e)
         raise PreventUpdate
 
     pose_with_pi_ip = {**pose, "pi_ip": pi_ip}
-    cam_options = [{"label": k, "value": k} for k in pi_cameras.keys()]
+    cam_options = [{"label": name, "value": name} for name in pi_cameras]
 
     return pose_with_pi_ip, pi_cameras, cam_options, first_cam_name
 
@@ -390,7 +566,22 @@ def get_pi_camera_from_dropdown(site_name, available_stream, camera_info):
     Input("available-stream-dropdown", "value"),
 )
 def update_stream_url(site_name):
+    """
+    Callback to update the video stream URL based on selected site.
+
+    Parameters
+    ----------
+    site_name : str
+        Selected site from dropdown.
+
+    Returns
+    -------
+    str
+        URL to the WEBRTC stream
+    """
     if not site_name:
         raise PreventUpdate
+
     stream_url = f"{cfg.MEDIAMTX_SERVER_IP}:8889/{site_name}"
+    logger.debug("Stream URL set to: %s", stream_url)
     return stream_url

--- a/app/callbacks/live_callbacks.py
+++ b/app/callbacks/live_callbacks.py
@@ -1,0 +1,414 @@
+from main import app
+import requests
+from dash import Input, Output, State, dcc, html, callback_context, no_update, ctx
+import datetime
+from dash.dependencies import ALL
+from utils.display import build_vision_polygon
+import json
+from dash import Input, Output, State, exceptions
+from utils.live_stream import fetch_cameras, find_closest_camera_pose  # replace with actual import
+import pandas as pd
+from io import StringIO
+from dash import Input, Output, State, callback_context
+from dash.exceptions import PreventUpdate
+
+
+# API Communication
+def send_api_request(FASTAPI_URL, endpoint: str):
+    try:
+        response = requests.post(f"{FASTAPI_URL}{endpoint}")
+        return response.json().get("message", "Unknown response")
+    except requests.exceptions.RequestException:
+        return "Error: Could not reach API server."
+
+
+
+@app.callback(
+    Output("dummy-output", "children"), 
+    Input("start-stream", "n_clicks"),
+    Input("stop-stream", "n_clicks"),
+    Input("move-up", "n_clicks"),
+    Input("move-down", "n_clicks"),
+    Input("move-left", "n_clicks"),
+    Input("move-right", "n_clicks"),
+    Input("stop-move", "n_clicks"),
+    Input("zoom-input", "value"),
+    State("camera-select", "value"),
+    State("speed-input", "value"),
+    State("selected-camera-pose", "data"),  
+    prevent_initial_call=True,
+)
+def control_camera(
+    start_stream,
+    stop_stream,
+    up,
+    down,
+    left,
+    right,
+    stop,
+    zoom_level,
+    camera_id,
+    move_speed,
+    selected_camera,
+):
+    print("[control_camera] Triggered with args:", locals())
+    ctx = callback_context
+    if not ctx.triggered or not selected_camera:
+        raise PreventUpdate
+
+    button_id = ctx.triggered[0]["prop_id"].split(".")[0]
+
+    if selected_camera["camera"] != camera_id:
+        raise PreventUpdate
+
+    # Use the Pi IP instead of the camera IP
+    pi_ip = selected_camera.get("pi_ip")
+    if not pi_ip:
+        raise PreventUpdate
+
+
+    direction_map = {
+        "move-up": "Up",
+        "move-down": "Down",
+        "move-left": "Left",
+        "move-right": "Right",
+        "stop-move": "Stop",
+    }
+
+    if button_id == "start-stream":
+        send_api_request(f"http://{pi_ip}:8081", f"/start_stream/{camera_id}")
+
+    elif button_id == "stop-stream":
+        send_api_request(f"http://{pi_ip}:8081", "/stop_stream")
+
+    elif button_id in direction_map:
+        direction = direction_map[button_id]
+        if direction != "Stop":
+            true_speed = int(move_speed / 10) + 1
+            print("mooooove to ",
+                f"http://{pi_ip}:8081",
+                f"/move/{camera_id}?direction={direction}&speed={true_speed}"
+            )
+            send_api_request(
+                f"http://{pi_ip}:8081",
+                f"/move/{camera_id}?direction={direction}&speed={true_speed}"
+            )
+        else:
+            send_api_request(f"http://{pi_ip}:8081", f"/stop/{camera_id}")
+
+    elif button_id == "zoom-input":
+        if zoom_level is not None:
+            true_zoom = int(zoom_level * 64 / 100)  # because backend expects 0–64
+            send_api_request(
+                f"http://{pi_ip}:8081",
+                f"/zoom/{camera_id}/{true_zoom}"
+            )
+
+
+
+    return no_update
+
+
+
+
+
+start_time = None
+
+
+@app.callback(
+    Output("stream-timer", "disabled"),
+    Output("detection-status", "data"),
+    Input("start-stream", "n_clicks"),
+    Input("stop-stream", "n_clicks"),
+    prevent_initial_call=True,
+)
+def control_detection(start_clicks, stop_clicks):
+    print("[control_detection] Triggered with args:", locals())
+
+    triggered = ctx.triggered_id
+    global start_time
+
+    if triggered == "start-stream":
+        start_time = datetime.datetime.now()
+        return False, "running"  # Enable timer
+    elif triggered == "stop-stream":
+        start_time = None
+        return True, "stopped"  # Disable timer
+
+    return no_update, no_update
+
+
+@app.callback(
+    Output("stream-status", "children"),
+    Input("stream-timer", "n_intervals"),
+    State("detection-status", "data"),
+    prevent_initial_call=True,
+)
+def update_status(n, detection_status):
+
+    if detection_status == "running" and start_time:
+        elapsed = datetime.datetime.now() - start_time
+        minutes, seconds = divmod(int(elapsed.total_seconds()), 60)
+        timer_text = f"{minutes:02d}:{seconds:02d}"
+        return html.Div(
+            [
+                html.Span(
+                    "🔴 Live stream",
+                    style={
+                        "backgroundColor": "#f99",
+                        "color": "black",
+                        "borderRadius": "6px",
+                        "padding": "4px 8px",
+                        "marginRight": "8px",
+                        "fontWeight": "bold",
+                    },
+                ),
+                html.Span(
+                    f"Levée de doute en cours, la détection n'est plus active depuis {timer_text}"
+                ),
+            ]
+        )
+    else:
+        return ""
+
+
+@app.callback(
+    Output("pose-buttons", "children"),
+    Input("camera-select", "value"),
+    State("pi-cameras", "data"),
+    prevent_initial_call=True,
+)
+def update_pose_buttons(camera_name, pi_cameras):
+    print("[update_pose_buttons] Triggered with args:", locals())
+
+    if not camera_name or not pi_cameras:
+        return ""
+
+    camera_info = pi_cameras.get(camera_name)
+    if not camera_info:
+        return ""
+
+    buttons = []
+    poses = camera_info.get("poses", [])
+    azimuths = camera_info.get("azimuths", [])
+
+    for pose_id, az in zip(poses, azimuths):
+        buttons.append(
+            html.Button(
+                f"{az}°",
+                id={"type": "pose-button", "camera": camera_name, "index": pose_id},
+                n_clicks=0,
+                style={
+                    "background": "none",
+                    "border": "2px solid #098386",
+                    "borderRadius": "8px",
+                    "fontSize": "16px",
+                    "cursor": "pointer",
+                    "padding": "6px 12px",
+                    "color": "#098386",
+                },
+            )
+        )
+
+    return buttons
+
+
+@app.callback(
+    Input({"type": "pose-button", "camera": ALL, "index": ALL}, "n_clicks"),
+    State("camera-select", "value"),
+    State("pi-cameras", "data"),
+    prevent_initial_call=True,
+)
+def move_to_pose(n_clicks_list, camera_name, pi_cameras):
+    print("[move_to_pose] Triggered with args:", locals())
+
+    triggered = ctx.triggered_id
+
+    if not triggered or not pi_cameras or not camera_name:
+        raise PreventUpdate
+
+    triggered_camera = triggered["camera"]
+    pose_id = triggered["index"]
+
+    if triggered_camera != camera_name:
+        raise PreventUpdate
+
+    camera_info = pi_cameras.get(camera_name)
+    if not camera_info:
+        raise PreventUpdate
+
+    camera_ip = camera_info["ip"]
+    fastapi_url = f"http://{camera_ip}:8081"
+
+    try:
+        response = requests.post(f"{fastapi_url}/move/{camera_ip}?pose_id={pose_id}&speed=50")
+        print("Move to pose response:", response.json())
+    except Exception as e:
+        print(f"Move to pose error: {e}")
+        raise PreventUpdate
+
+
+
+
+
+
+
+@app.callback(
+    Output("vision-layer", "children"),
+    Input("camera-select", "value"),
+    Input({"type": "pose-button", "camera": ALL, "index": ALL}, "n_clicks"),
+    State("pi-cameras", "data"),
+    State("api_cameras", "data"),
+    prevent_initial_call=True,
+)
+def update_cone(camera_name, n_clicks_list, pi_cameras, api_cameras_data):
+    print("[update_cone] Triggered with args:", locals())
+
+    triggered = ctx.triggered_id
+
+    if not triggered or not camera_name or not pi_cameras or not api_cameras_data:
+        raise PreventUpdate
+
+    camera_info = pi_cameras.get(camera_name)
+    if not camera_info:
+        raise PreventUpdate
+
+    # Load full camera metadata
+    df_cams = pd.read_json(StringIO(api_cameras_data), orient="split")
+    row = df_cams[df_cams["name"] == camera_name]
+
+    if row.empty:
+        print(f"[update_cone] Camera {camera_name} not found in metadata.")
+        raise PreventUpdate
+
+    site_lat = float(row["lat"].values[0])
+    site_lon = float(row["lon"].values[0])
+    opening_angle = int(row["angle_of_view"].values[0])
+    dist_km = 10  # If you want to replace this, extract it from elsewhere or make it a constant
+
+    poses = camera_info.get("poses", [])
+    azimuths = camera_info.get("azimuths", [])
+
+    try:
+        # Case 1: Camera selection
+        if triggered == "camera-select":
+            pose_index = 0
+
+        # Case 2: Pose button click
+        else:
+            pose_id = int(triggered["index"])
+            pose_index = poses.index(pose_id)
+
+
+        new_azimuth = azimuths[pose_index]
+        cone, _ = build_vision_polygon(
+            site_lat=site_lat,
+            site_lon=site_lon,
+            azimuth=new_azimuth,
+            opening_angle=opening_angle,
+            dist_km=dist_km,
+        )
+        return [cone]
+
+    except Exception as e:
+        print(f"Error building vision cone: {e}")
+        return no_update
+   
+@app.callback(
+    Output("available-stream-dropdown", "value"),
+    Input("selected-camera-info", "data"),
+    State("available-stream", "data"),
+    prevent_initial_call=True,
+)
+def sync_dropdown_from_camera_info(camera_info, available_stream):
+    print("[sync_dropdown_from_camera_info] Triggered with:", camera_info)
+
+    if not camera_info or not available_stream:
+        raise exceptions.PreventUpdate
+
+    cam_name, _ = camera_info
+    site_name = cam_name[:-3].strip().lower()
+
+    print("!!!!!! sync_dropdown_from_camera_info", site_name, available_stream)
+
+    if site_name not in available_stream:
+        print(f"[sync_dropdown_from_camera_info] '{site_name}' not in available_stream")
+        raise exceptions.PreventUpdate
+
+    return site_name
+
+
+@app.callback(
+    Output("selected-camera-pose", "data"),
+    Output("pi-cameras", "data"),
+    Output("camera-select", "options"),
+    Output("camera-select", "value"),
+    Input("available-stream-dropdown", "value"),
+    State("available-stream", "data"),
+    State("selected-camera-info", "data"),
+    prevent_initial_call=True,
+)
+def get_pi_camera_from_dropdown(site_name, available_stream, camera_info):
+    print("[get_pi_camera_from_dropdown] Triggered with:", site_name)
+
+    if not site_name or not available_stream:
+        raise PreventUpdate
+
+    pi_ip = available_stream.get(site_name)
+    if not pi_ip:
+        print(f"No Pi IP found for {site_name}")
+        raise PreventUpdate
+
+    pi_api_url = f"http://{pi_ip}:8081"
+    print(f"Querying Pi at: {pi_api_url}")
+
+    try:
+        pi_cameras = fetch_cameras(pi_api_url)
+    except Exception as e:
+        print(f"Error fetching cameras from {pi_api_url}: {e}")
+        raise PreventUpdate
+
+    if not pi_cameras:
+        print("No cameras found")
+        raise PreventUpdate
+
+    first_cam_name = list(pi_cameras.keys())[0]
+    cam_info = pi_cameras[first_cam_name]
+    azimuths = cam_info.get("azimuths", [])
+    poses = cam_info.get("poses", [])
+
+    if not azimuths or not poses:
+        print("Camera has no pose or azimuth info")
+        raise PreventUpdate
+
+    # Use azimuth from selected-camera-info, fallback to azimuth[0]
+    target_azimuth = camera_info[1] if camera_info else azimuths[0]
+
+    try:
+        pose = find_closest_camera_pose(target_azimuth, pi_cameras)
+    except Exception as e:
+        print(f"Error finding closest camera pose: {e}")
+        raise PreventUpdate
+
+    pose_with_pi_ip = {**pose, "pi_ip": pi_ip}
+    cam_options = [{"label": k, "value": k} for k in pi_cameras.keys()]
+
+    return pose_with_pi_ip, pi_cameras, cam_options, first_cam_name
+
+
+
+
+
+@app.callback(
+    Output("video-stream", "src"),
+    Input("selected-camera-pose", "data"),
+   
+)
+def update_stream_url(camera_pose):
+    if not camera_pose:
+        raise PreventUpdate
+    ip = camera_pose["ip"]
+    stream_url = f"http://{ip}:8889/stream"  # Adjust if needed
+    return stream_url
+
+

--- a/app/components/navbar.py
+++ b/app/components/navbar.py
@@ -27,16 +27,37 @@ def Navbar(lang="fr"):
             ),
             html.Div(
                 className="ml-auto",
-                style={"display": "flex", "flexDirection": "row", "gap": "10px", "marginRight": "10px"},
+                style={
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "gap": "10px",
+                    "marginRight": "10px",
+                },
                 children=[
-                    # 📅 Date Picker Button
+                    # 🔔 Home Alerte
+                    dbc.Button(
+                        id="home-button",
+                        children=["🔔 ", html.Span(id="home_button_text")],
+                        href="/",
+                        color="light",
+                        style={"fontSize": "16px"},
+                    ),
+                    # 🎥 Live Stream
+                    dbc.Button(
+                        id="live-stream-button",
+                        children=["🎥 ", html.Span(id="live_stream_button_text")],
+                        href="/live-stream",
+                        color="light",
+                        style={"fontSize": "16px"},
+                    ),
+                    # 📅 Date Picker
                     dbc.Button(
                         id="open-datepicker-modal",
                         children=["📅 ", html.Span(id="datepicker_button_text")],
                         color="light",
                         style={"fontSize": "16px"},
                     ),
-                    # 📷 Camera Status Button
+                    # 📷 Camera Status
                     dbc.Button(
                         id="camera-status-button",
                         children=["📷 ", html.Span(id="camera_status_button_text")],
@@ -44,7 +65,7 @@ def Navbar(lang="fr"):
                         color="light",
                         style={"fontSize": "16px"},
                     ),
-                    # 🚨 Alarm Button
+                    # 🚨 Alarm
                     dbc.Button(
                         id="alarm-status-button",
                         children=["🚨 ", html.Span(id="blinking_alarm_button_text")],
@@ -52,7 +73,7 @@ def Navbar(lang="fr"):
                         color="light",
                         style={"fontSize": "16px"},
                     ),
-                    # 🌐 Language Buttons
+                    # 🌐 Langues
                     dbc.Button(["🇫🇷", " FR"], id="btn-fr", color="light", className="mr-2"),
                     dbc.Button(["🇪🇸", " ES"], id="btn-es", color="light"),
                 ],
@@ -64,17 +85,12 @@ def Navbar(lang="fr"):
         style={"display": "flex", "justify-content": "space-between"},
     )
 
-    # Modal with DatePicker
     datepicker_modal = dbc.Modal(
         [
-            dbc.ModalHeader("Sélectionnez une date" if lang == "fr" else "Select a date"),
-            dbc.ModalBody(
-                dcc.DatePickerSingle(
-                    id="my-date-picker-single",
-                )
-            ),
+            dbc.ModalHeader("Sélectionnez une date" if lang == "fr" else "Seleccione una fecha"),
+            dbc.ModalBody(dcc.DatePickerSingle(id="my-date-picker-single")),
             dbc.ModalFooter(
-                dbc.Button("Fermer" if lang == "fr" else "Close", id="close-datepicker-modal", className="ml-auto")
+                dbc.Button("Fermer" if lang == "fr" else "Cerrar", id="close-datepicker-modal", className="ml-auto")
             ),
         ],
         id="datepicker-modal",

--- a/app/config.py
+++ b/app/config.py
@@ -29,6 +29,9 @@ SERVER_NAME: Optional[str] = os.getenv("SERVER_NAME")
 # Safeguards
 SAFE_DEV_MODE: Optional[str] = os.getenv("SAFE_DEV_MODE")
 
+# Stream server
+MEDIAMTX_SERVER_IP = os.environ.get("MEDIAMTX_SERVER_IP", "")
+
 # App config variables
 MAX_ALERTS_PER_EVENT = 10
 CAM_OPENING_ANGLE = 87

--- a/app/index.py
+++ b/app/index.py
@@ -54,10 +54,7 @@ def display_page(pathname, api_cameras, search, selected_camera_info, user_token
     if lang not in cfg.AVAILABLE_LANGS:
         lang = cfg.DEFAULT_LANGUAGE
 
-        print("display page")
-
     if not isinstance(user_token, str) or not user_token:
-        print("display page login")
         return login_layout(lang=lang)
 
     triggered = dash.ctx.triggered_id
@@ -66,7 +63,6 @@ def display_page(pathname, api_cameras, search, selected_camera_info, user_token
         return live_stream_layout(user_token, api_cameras, available_stream, selected_camera_info, lang=lang)
 
     if pathname == "/" or pathname is None:
-        print("display page main")
         return homepage_layout(user_token, api_cameras, lang=lang)
     if pathname == "/cameras-status":
         return cameras_status_layout(user_token, api_cameras, lang=lang)

--- a/app/index.py
+++ b/app/index.py
@@ -2,6 +2,8 @@
 
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
+
+
 import argparse
 import urllib.parse
 
@@ -17,6 +19,7 @@ import config as cfg
 from pages.blinking_alarm import blinking_alarm_layout
 from pages.cameras_status import cameras_status_layout
 from pages.homepage import homepage_layout
+from pages.live_stream import live_stream_layout
 from pages.login import login_layout
 
 # Configure logging
@@ -54,6 +57,8 @@ def display_page(pathname, api_cameras, search, user_token):
         return cameras_status_layout(user_token, api_cameras, lang=lang)
     if pathname == "/blinking-alarm":
         return blinking_alarm_layout(user_token, api_cameras, lang=lang)
+    if pathname == "/live-stream":
+        return live_stream_layout(user_token, api_cameras, lang=lang)
     else:
         logger.warning("Unable to find page for pathname: %s", pathname)
         return html.Div([html.P("Unable to find this page.", className="alert alert-warning")])

--- a/app/index.py
+++ b/app/index.py
@@ -9,6 +9,9 @@ import urllib.parse
 
 import dash
 import logging_config
+import callbacks.data_callbacks
+import callbacks.live_callbacks
+import callbacks.display_callbacks  # noqa: F401
 from dash import html
 from dash.dependencies import Input, Output, State
 from layouts.main_layout import get_main_layout
@@ -35,7 +38,7 @@ app.layout = get_main_layout()
         Input("url", "pathname"),
         Input("api_cameras", "data"),
         Input("url", "search"),
-        Input("selected-camera-info", "data"),  # NEW
+        Input("selected-camera-info", "data"), 
     ],
     [State("user_token", "data"), State("available-stream", "data")],
 )
@@ -51,7 +54,10 @@ def display_page(pathname, api_cameras, search, selected_camera_info, user_token
     if lang not in cfg.AVAILABLE_LANGS:
         lang = cfg.DEFAULT_LANGUAGE
 
+        print("display page")
+
     if not isinstance(user_token, str) or not user_token:
+        print("display page login")
         return login_layout(lang=lang)
 
     triggered = dash.ctx.triggered_id
@@ -60,6 +66,7 @@ def display_page(pathname, api_cameras, search, selected_camera_info, user_token
         return live_stream_layout(user_token, api_cameras, available_stream, selected_camera_info, lang=lang)
 
     if pathname == "/" or pathname is None:
+        print("display page main")
         return homepage_layout(user_token, api_cameras, lang=lang)
     if pathname == "/cameras-status":
         return cameras_status_layout(user_token, api_cameras, lang=lang)

--- a/app/index.py
+++ b/app/index.py
@@ -7,6 +7,9 @@
 import argparse
 import urllib.parse
 
+import callbacks.data_callbacks
+import callbacks.display_callbacks
+import callbacks.live_callbacks
 import dash
 import logging_config
 from dash import html

--- a/app/index.py
+++ b/app/index.py
@@ -7,15 +7,12 @@
 import argparse
 import urllib.parse
 
-import callbacks.data_callbacks
-import callbacks.live_callbacks
-import callbacks.display_callbacks  # noqa: F401
+import dash
 import logging_config
 from dash import html
 from dash.dependencies import Input, Output, State
 from layouts.main_layout import get_main_layout
 from main import app
-import dash
 
 import config as cfg
 from pages.blinking_alarm import blinking_alarm_layout

--- a/app/index.py
+++ b/app/index.py
@@ -9,9 +9,6 @@ import urllib.parse
 
 import dash
 import logging_config
-import callbacks.data_callbacks
-import callbacks.live_callbacks
-import callbacks.display_callbacks  # noqa: F401
 from dash import html
 from dash.dependencies import Input, Output, State
 from layouts.main_layout import get_main_layout
@@ -38,7 +35,7 @@ app.layout = get_main_layout()
         Input("url", "pathname"),
         Input("api_cameras", "data"),
         Input("url", "search"),
-        Input("selected-camera-info", "data"), 
+        Input("selected-camera-info", "data"),
     ],
     [State("user_token", "data"), State("available-stream", "data")],
 )

--- a/app/index.py
+++ b/app/index.py
@@ -40,7 +40,7 @@ app.layout = get_main_layout()
         Input("url", "search"),
         Input("selected-camera-info", "data"),
     ],
-    [State("user_token", "data"), State("available-stream", "data")],
+    [State("user_token", "data"), State("available-stream-sites", "data")],
 )
 def display_page(pathname, api_cameras, search, selected_camera_info, user_token, available_stream):
     logger.debug(

--- a/app/layouts/main_layout.py
+++ b/app/layouts/main_layout.py
@@ -74,9 +74,5 @@ def get_main_layout():
             dcc.Store(id="selected-camera-info", storage_type="session"),
             dcc.Store(id="selected-camera-pose", storage_type="session"),
             dcc.Store(id="pi-cameras", storage_type="session"),
-            
-
-
-
         ]
     )

--- a/app/layouts/main_layout.py
+++ b/app/layouts/main_layout.py
@@ -70,9 +70,7 @@ def get_main_layout():
             dcc.Store(id="user_name", storage_type="session"),
             dcc.Store(id="to_acknowledge", data=0),
             dcc.Store(id="trigger_no_detections", data=False),
-            dcc.Store(id="available-stream", storage_type="session"),
+            dcc.Store(id="available-stream-sites", storage_type="session"),
             dcc.Store(id="selected-camera-info", storage_type="session"),
-            dcc.Store(id="selected-camera-pose", storage_type="session"),
-            dcc.Store(id="pi-cameras", storage_type="session"),
         ]
     )

--- a/app/layouts/main_layout.py
+++ b/app/layouts/main_layout.py
@@ -67,8 +67,16 @@ def get_main_layout():
             dcc.Store(id="bbox_visibility", data={"visible": True}),
             # Storage components saving the user's headers and credentials
             dcc.Store(id="user_token", storage_type="session", data=user_token),
-            # [TEMPORARY FIX] Storing the user's credentials to refresh the token when needed
+            dcc.Store(id="user_name", storage_type="session"),
             dcc.Store(id="to_acknowledge", data=0),
             dcc.Store(id="trigger_no_detections", data=False),
+            dcc.Store(id="available-stream", storage_type="session"),
+            dcc.Store(id="selected-camera-info", storage_type="session"),
+            dcc.Store(id="selected-camera-pose", storage_type="session"),
+            dcc.Store(id="pi-cameras", storage_type="session"),
+            
+
+
+
         ]
     )

--- a/app/pages/homepage.py
+++ b/app/pages/homepage.py
@@ -337,7 +337,6 @@ def homepage_layout(user_token, api_cameras, lang="fr"):
                                     },
                                 ),
                             ),
-                            
                             html.Div(
                                 dbc.Button(
                                     translate[lang]["enlarge_map"],
@@ -346,14 +345,8 @@ def homepage_layout(user_token, api_cameras, lang="fr"):
                                     id="map-button",
                                 ),
                             ),
-                            dbc.Button(
-                                "Start Live Stream",
-                                id="start-live-stream",
-                                color="primary",
-                                className="mb-3"
-                            ),
-                            
-                                        ],
+                            dbc.Button("Start Live Stream", id="start-live-stream", color="primary", className="mb-3"),
+                        ],
                         width=2,
                         style={
                             "display": "flex",
@@ -377,8 +370,6 @@ def homepage_layout(user_token, api_cameras, lang="fr"):
                 is_open=False,
             ),
             dcc.Store(id="language", data=lang),
-            
-
         ],
         fluid=True,
     )

--- a/app/pages/homepage.py
+++ b/app/pages/homepage.py
@@ -337,6 +337,7 @@ def homepage_layout(user_token, api_cameras, lang="fr"):
                                     },
                                 ),
                             ),
+                            
                             html.Div(
                                 dbc.Button(
                                     translate[lang]["enlarge_map"],
@@ -345,7 +346,14 @@ def homepage_layout(user_token, api_cameras, lang="fr"):
                                     id="map-button",
                                 ),
                             ),
-                        ],
+                            dbc.Button(
+                                "Start Live Stream",
+                                id="start-live-stream",
+                                color="primary",
+                                className="mb-3"
+                            ),
+                            
+                                        ],
                         width=2,
                         style={
                             "display": "flex",
@@ -369,6 +377,8 @@ def homepage_layout(user_token, api_cameras, lang="fr"):
                 is_open=False,
             ),
             dcc.Store(id="language", data=lang),
+            
+
         ],
         fluid=True,
     )

--- a/app/pages/live_stream.py
+++ b/app/pages/live_stream.py
@@ -3,12 +3,14 @@
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
+from typing import List, TypedDict
+
 import dash_bootstrap_components as dbc
 from dash import dcc, html
 from dash_extensions import EventListener  # type: ignore
 
 from utils.display import build_alerts_map
-from typing import TypedDict, List
+
 
 class Option(TypedDict):
     label: str
@@ -126,7 +128,6 @@ def live_stream_layout(user_token, api_cameras, available_stream, selected_camer
     default_stream = next(iter(available_stream.keys()))[0] if available_stream else None
     dropdown_options: List[Option] = [{"label": name, "value": name} for name in available_stream.keys()]
 
-
     # Try to derive stream from selected camera info
     if selected_camera_info and available_stream:
         cam_name, _ = selected_camera_info
@@ -146,9 +147,7 @@ def live_stream_layout(user_token, api_cameras, available_stream, selected_camer
                                 id="available-stream-sites-dropdown",
                                 placeholder=translate[lang]["select_stream"],
                                 value=default_stream,
-                                options=dropdown_options
-                                if available_stream
-                                else [],
+                                options=dropdown_options if available_stream else [],
                                 style=PICK_STREAM_STYLE,
                             ),
                             html.Div(

--- a/app/pages/live_stream.py
+++ b/app/pages/live_stream.py
@@ -3,13 +3,19 @@
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
-from typing import Dict, List
+from typing import List, TypedDict
 
 import dash_bootstrap_components as dbc
 from dash import dcc, html
 from dash_extensions import EventListener  # type: ignore
 
 from utils.display import build_alerts_map
+
+
+class Option(TypedDict):
+    label: str
+    value: str
+
 
 # --- Styles ---
 STATUS_BAR_STYLE = {
@@ -121,11 +127,9 @@ def live_stream_layout(user_token, api_cameras, available_stream, selected_camer
     # Default fallback
     default_stream = next(iter(available_stream.keys()))[0] if available_stream else None
 
-    # Change the type hint here
-    dropdown_options: List[Dict[str, str]] = []  # <--- MODIFIED LINE
+    dropdown_options: List[Option] = []
 
     if available_stream:
-        # This list comprehension already creates List[Dict[str, str]], which is fine
         dropdown_options = [{"label": name, "value": name} for name in available_stream.keys()]
 
     # Try to derive stream from selected camera info
@@ -147,7 +151,7 @@ def live_stream_layout(user_token, api_cameras, available_stream, selected_camer
                                 id="available-stream-sites-dropdown",
                                 placeholder=translate[lang]["select_stream"],
                                 value=default_stream,
-                                options=dropdown_options if available_stream else [],
+                                options=dropdown_options if available_stream else [],  # type: ignore[arg-type]
                                 style=PICK_STREAM_STYLE,
                             ),
                             html.Div(

--- a/app/pages/live_stream.py
+++ b/app/pages/live_stream.py
@@ -3,15 +3,13 @@
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
-from typing import List, Dict
+from typing import Dict, List
 
 import dash_bootstrap_components as dbc
 from dash import dcc, html
 from dash_extensions import EventListener  # type: ignore
 
 from utils.display import build_alerts_map
-
-
 
 # --- Styles ---
 STATUS_BAR_STYLE = {
@@ -124,7 +122,7 @@ def live_stream_layout(user_token, api_cameras, available_stream, selected_camer
     default_stream = next(iter(available_stream.keys()))[0] if available_stream else None
 
     # Change the type hint here
-    dropdown_options: List[Dict[str, str]] = [] # <--- MODIFIED LINE
+    dropdown_options: List[Dict[str, str]] = []  # <--- MODIFIED LINE
 
     if available_stream:
         # This list comprehension already creates List[Dict[str, str]], which is fine

--- a/app/pages/live_stream.py
+++ b/app/pages/live_stream.py
@@ -5,6 +5,7 @@
 
 import dash_bootstrap_components as dbc
 from dash import dcc, html
+from dash_extensions import EventListener
 
 from utils.display import build_alerts_map
 
@@ -142,206 +143,6 @@ def live_stream_layout(user_token, api_cameras, available_stream, selected_camer
                                 else [],
                                 style=PICK_STREAM_STYLE,
                             ),
-                        ],
-                        style={"display": "flex", "alignItems": "center", "gap": "8px", "marginRight": "16px"},
-                    ),
-                ],
-                style=STATUS_BAR_STYLE,
-            ),
-            # Main layout: stream + map
-            dbc.Row(
-                [
-                    # LEFT COLUMN: Stream + Controls
-                    dbc.Col(
-                        [
-                            html.Div(
-                                [
-                                    html.Iframe(
-                                        id="video-stream",
-                                        src="",
-                                        style={
-                                            "width": "100%",
-                                            "height": "500px",
-                                            "border": "none",
-                                            "borderRadius": "10px",
-                                        },
-                                    ),
-                                    # Joystick
-                                    html.Div(
-                                        [
-                                            dbc.Row(
-                                                [
-                                                    dbc.Col(),
-                                                    dbc.Col(
-                                                        html.Button("⬆️", id="move-up", n_clicks=0, style=BUTTON_STYLE)
-                                                    ),
-                                                    dbc.Col(),
-                                                ],
-                                                justify="center",
-                                            ),
-                                            dbc.Row(
-                                                [
-                                                    dbc.Col(
-                                                        html.Button("⬅️", id="move-left", n_clicks=0, style=BUTTON_STYLE)
-                                                    ),
-                                                    dbc.Col(
-                                                        html.Button(
-                                                            "🛑", id="stop-move", n_clicks=0, style=BUTTON_STYLE
-                                                        )
-                                                    ),
-                                                    dbc.Col(
-                                                        html.Button(
-                                                            "➡️", id="move-right", n_clicks=0, style=BUTTON_STYLE
-                                                        )
-                                                    ),
-                                                ],
-                                                justify="center",
-                                            ),
-                                            dbc.Row(
-                                                [
-                                                    dbc.Col(),
-                                                    dbc.Col(
-                                                        html.Button("⬇️", id="move-down", n_clicks=0, style=BUTTON_STYLE)
-                                                    ),
-                                                    dbc.Col(),
-                                                ],
-                                                justify="center",
-                                            ),
-                                        ],
-                                        style={
-                                            "position": "absolute",
-                                            "bottom": "10px",
-                                            "right": "10px",
-                                            "padding": "5px",
-                                            "borderRadius": "8px",
-                                        },
-                                    ),
-                                ],
-                                style={"position": "relative"},
-                            ),
-                            # Sliders
-                            dbc.Row(
-                                [
-                                    dbc.Col(
-                                        html.Div(
-                                            [
-                                                html.Div(
-                                                    translate[lang]["move_speed"],
-                                                    style={
-                                                        "textAlign": "center",
-                                                        "fontWeight": "bold",
-                                                        "marginBottom": "8px",
-                                                    },
-                                                ),
-                                                dcc.Slider(
-                                                    id="speed-input",
-                                                    min=0,
-                                                    max=100,
-                                                    step=10,
-                                                    value=0,
-                                                    marks={i: str(i) for i in range(0, 101, 10)},
-                                                ),
-                                            ],
-                                            style=SLIDER_BOX_STYLE,
-                                        ),
-                                        width=6,
-                                    ),
-                                    dbc.Col(
-                                        html.Div(
-                                            [
-                                                html.Div(
-                                                    translate[lang]["zoom_level"],
-                                                    style={
-                                                        "textAlign": "center",
-                                                        "fontWeight": "bold",
-                                                        "marginBottom": "8px",
-                                                    },
-                                                ),
-                                                dcc.Slider(
-                                                    id="zoom-input",
-                                                    min=0,
-                                                    max=100,
-                                                    step=10,
-                                                    value=0,
-                                                    marks={i: str(i) for i in range(0, 101, 10)},
-                                                ),
-                                            ],
-                                            style=SLIDER_BOX_STYLE,
-                                        ),
-                                        width=6,
-                                    ),
-                                ],
-                                className="mt-3",
-                            ),
-                        ],
-                        md=8,
-                        style={"padding": "0"},
-                    ),
-                    # RIGHT COLUMN: Dropdown + map
-                    dbc.Col(
-                        [  # Panneau affichage des infos caméra
-                            html.Div(
-                                id="stream-camera-info-panel",
-                                className="common-style",
-                                style={
-                                    "padding": "12px",
-                                    "marginTop": "0px",
-                                    "marginBottom": "10px",
-                                    "backgroundColor": "#f0f4f7",
-                                    "borderRadius": "8px",
-                                },
-                                children=[
-                                    html.H5(
-                                        "🎥 Informations caméra", style={"textAlign": "center", "marginBottom": "12px"}
-                                    ),
-                                    html.Div(
-                                        [
-                                            html.Span("Nom de la caméra : ", className="alert-information-title"),
-                                            html.Span(id="stream-camera-name"),
-                                        ],
-                                        style={"marginBottom": "8px"},
-                                    ),
-                                    html.Div(
-                                        [
-                                            html.Span("Azimuth actuel : ", className="alert-information-title"),
-                                            dcc.Input(
-                                                id="stream-current-azimuth",
-                                                type="number",
-                                                min=0,
-                                                max=359,
-                                                step=1,
-                                                placeholder="0-359",
-                                                debounce=True,
-                                                style={"width": "80px", "marginLeft": "8px", "borderRadius": "6px"},
-                                            ),
-                                        ],
-                                        style={"marginBottom": "12px", "display": "flex", "alignItems": "center"},
-                                    ),
-                                    html.Div(
-                                        [
-                                            html.Span(
-                                                "Azimuths préenregistrés : ", className="alert-information-title"
-                                            ),
-                                            html.Span(id="stream-preset-azimuths", style={"marginLeft": "8px"}),
-                                        ],
-                                        style={"marginBottom": "8px", "display": "flex", "alignItems": "center"},
-                                    ),
-                                ],
-                            ),
-                            # Map
-                            html.Div(
-                                dbc.Col(
-                                    build_alerts_map(api_cameras, id_suffix="-stream"),
-                                    className="common-style",
-                                    style={
-                                        "position": "relative",
-                                        "width": "100%",
-                                        "height": "380px",
-                                        "borderRadius": "10px",
-                                        "overflow": "hidden",
-                                    },
-                                )
-                            ),
                             html.Div(
                                 html.Button(
                                     "📸 Capturer une image",
@@ -349,14 +150,286 @@ def live_stream_layout(user_token, api_cameras, available_stream, selected_camer
                                     n_clicks=0,
                                     className="btn btn-primary",
                                 ),
-                                style={"textAlign": "center", "marginTop": "12px"},
+                                style={"textAlign": "center"},
                             ),
                         ],
-                        md=4,
-                        style={"padding": "0", "paddingLeft": "16px"},
+                        style={"display": "flex", "alignItems": "center", "gap": "8px", "marginRight": "16px"},
                     ),
                 ],
-                className="mb-4",
+                style=STATUS_BAR_STYLE,
+            ),
+            # Main layout: stream + map
+            html.Div(
+                dbc.Row(
+                    [
+                        # LEFT COLUMN: Stream + Controls
+                        dbc.Col(
+                            [
+                                html.Div(
+                                    [
+                                        html.Div(
+                                            [
+                                                html.Iframe(
+                                                    id="video-stream",
+                                                    src="",
+                                                    style={
+                                                        "position": "absolute",
+                                                        "top": "0",
+                                                        "left": "0",
+                                                        "width": "100%",
+                                                        "height": "100%",
+                                                        "border": "none",
+                                                        "borderRadius": "10px",
+                                                    },
+                                                ),
+                                                EventListener(
+                                                    id="click-listener",
+                                                    children=html.Div(
+                                                        id="click-overlay",
+                                                        n_clicks=0,
+                                                        style={
+                                                            "position": "absolute",
+                                                            "top": 0,
+                                                            "left": 0,
+                                                            "width": "100%",
+                                                            "height": "100%",
+                                                            "zIndex": 2,
+                                                            "cursor": "crosshair",
+                                                            "backgroundColor": "rgba(255, 255, 255, 0.01)",
+                                                        },
+                                                    ),
+                                                    events=[{"event": "pointerdown"}],
+                                                ),
+                                                html.Div(
+                                                    [
+                                                        dbc.Row(
+                                                            [
+                                                                dbc.Col(),
+                                                                dbc.Col(
+                                                                    html.Button(
+                                                                        "⬆️",
+                                                                        id="move-up",
+                                                                        n_clicks=0,
+                                                                        style=BUTTON_STYLE,
+                                                                    )
+                                                                ),
+                                                                dbc.Col(),
+                                                            ],
+                                                            justify="center",
+                                                        ),
+                                                        dbc.Row(
+                                                            [
+                                                                dbc.Col(
+                                                                    html.Button(
+                                                                        "⬅️",
+                                                                        id="move-left",
+                                                                        n_clicks=0,
+                                                                        style=BUTTON_STYLE,
+                                                                    )
+                                                                ),
+                                                                dbc.Col(
+                                                                    html.Button(
+                                                                        "🛑",
+                                                                        id="stop-move",
+                                                                        n_clicks=0,
+                                                                        style=BUTTON_STYLE,
+                                                                    )
+                                                                ),
+                                                                dbc.Col(
+                                                                    html.Button(
+                                                                        "➡️",
+                                                                        id="move-right",
+                                                                        n_clicks=0,
+                                                                        style=BUTTON_STYLE,
+                                                                    )
+                                                                ),
+                                                            ],
+                                                            justify="center",
+                                                        ),
+                                                        dbc.Row(
+                                                            [
+                                                                dbc.Col(),
+                                                                dbc.Col(
+                                                                    html.Button(
+                                                                        "⬇️",
+                                                                        id="move-down",
+                                                                        n_clicks=0,
+                                                                        style=BUTTON_STYLE,
+                                                                    )
+                                                                ),
+                                                                dbc.Col(),
+                                                            ],
+                                                            justify="center",
+                                                        ),
+                                                    ],
+                                                    style={
+                                                        "position": "absolute",
+                                                        "bottom": "10px",
+                                                        "right": "10px",
+                                                        "padding": "5px",
+                                                        "borderRadius": "8px",
+                                                        "zIndex": 3,
+                                                    },
+                                                ),
+                                            ],
+                                            style={
+                                                "position": "relative",
+                                                "width": "100%",
+                                                "paddingBottom": "56.25%",  # 16:9 aspect ratio
+                                                "borderRadius": "10px",
+                                                "boxShadow": "0 0 8px rgba(0,0,0,0.2)",
+                                                "overflow": "hidden",
+                                            },
+                                        ),
+                                    ],
+                                    style={
+                                        "width": "100%",
+                                        "maxWidth": "1000px",  # Optional: limit max width for large screens
+                                        "margin": "auto",
+                                    },
+                                ),
+                                # Sliders
+                                dbc.Row(
+                                    [
+                                        dbc.Col(
+                                            html.Div(
+                                                [
+                                                    html.Div(
+                                                        translate[lang]["move_speed"],
+                                                        style={
+                                                            "textAlign": "center",
+                                                            "fontWeight": "bold",
+                                                            "marginBottom": "8px",
+                                                        },
+                                                    ),
+                                                    dcc.Slider(
+                                                        id="speed-input",
+                                                        min=0,
+                                                        max=100,
+                                                        step=10,
+                                                        value=0,
+                                                        marks={i: str(i) for i in range(0, 101, 10)},
+                                                    ),
+                                                ],
+                                                style=SLIDER_BOX_STYLE,
+                                            ),
+                                            width=6,
+                                        ),
+                                        dbc.Col(
+                                            html.Div(
+                                                [
+                                                    html.Div(
+                                                        translate[lang]["zoom_level"],
+                                                        style={
+                                                            "textAlign": "center",
+                                                            "fontWeight": "bold",
+                                                            "marginBottom": "8px",
+                                                        },
+                                                    ),
+                                                    dcc.Slider(
+                                                        id="zoom-input",
+                                                        min=0,
+                                                        max=100,
+                                                        step=10,
+                                                        value=0,
+                                                        marks={i: str(i) for i in range(0, 101, 10)},
+                                                    ),
+                                                ],
+                                                style=SLIDER_BOX_STYLE,
+                                            ),
+                                            width=6,
+                                        ),
+                                    ],
+                                    className="mt-3",
+                                ),
+                            ],
+                            md=8,
+                            style={"padding": "0"},
+                        ),
+                        # RIGHT COLUMN: Dropdown + map
+                        dbc.Col(
+                            [  # Panneau affichage des infos caméra
+                                html.Div(
+                                    id="stream-camera-info-panel",
+                                    className="common-style",
+                                    style={
+                                        "padding": "12px",
+                                        "marginTop": "0px",
+                                        "marginBottom": "10px",
+                                        "backgroundColor": "#f0f4f7",
+                                        "borderRadius": "8px",
+                                    },
+                                    children=[
+                                        html.H5(
+                                            "🎥 Informations caméra",
+                                            style={"textAlign": "center", "marginBottom": "12px"},
+                                        ),
+                                        html.Div(
+                                            [
+                                                html.Span("Nom de la caméra : ", className="alert-information-title"),
+                                                html.Span(id="stream-camera-name"),
+                                            ],
+                                            style={"marginBottom": "8px"},
+                                        ),
+                                        html.Div(
+                                            [
+                                                html.Span("Azimuth actuel : ", className="alert-information-title"),
+                                                dcc.Input(
+                                                    id="stream-current-azimuth",
+                                                    type="number",
+                                                    min=0,
+                                                    max=359,
+                                                    step=1,
+                                                    placeholder="0-359",
+                                                    debounce=True,
+                                                    style={"width": "80px", "marginLeft": "8px", "borderRadius": "6px"},
+                                                ),
+                                            ],
+                                            style={"marginBottom": "12px", "display": "flex", "alignItems": "center"},
+                                        ),
+                                        html.Div(
+                                            [
+                                                html.Span(
+                                                    "Azimuths préenregistrés : ", className="alert-information-title"
+                                                ),
+                                                html.Span(id="stream-preset-azimuths", style={"marginLeft": "8px"}),
+                                            ],
+                                            style={"marginBottom": "8px", "display": "flex", "alignItems": "center"},
+                                        ),
+                                    ],
+                                ),
+                                # Map
+                                html.Div(
+                                    [
+                                        html.Div(
+                                            build_alerts_map(api_cameras, id_suffix="-stream"),
+                                            style={
+                                                "position": "absolute",
+                                                "top": "0",
+                                                "left": "0",
+                                                "width": "100%",
+                                                "height": "100%",
+                                            },
+                                        )
+                                    ],
+                                    style={
+                                        "position": "relative",
+                                        "width": "100%",
+                                        "paddingBottom": "100%",
+                                        "borderRadius": "10px",
+                                        "overflow": "hidden",
+                                        "boxShadow": "0 0 8px rgba(0,0,0,0.2)",
+                                    },
+                                    className="common-style",
+                                ),
+                            ],
+                            md=4,
+                            style={"padding": "0", "paddingLeft": "16px"},
+                        ),
+                    ],
+                    className="mb-4",
+                ),
+                style={"paddingLeft": "20px", "paddingRight": "20px"},
             ),
             # Hidden components
             # Modal for image preview
@@ -379,17 +452,20 @@ def live_stream_layout(user_token, api_cameras, available_stream, selected_camer
                 ],
                 id="capture-modal",
                 is_open=False,
-                fullscreen=True,  # 👈 This makes it full-screen
+                fullscreen=True,
             ),
             dcc.Interval(id="stream-timer", interval=1000, n_intervals=0),  # every second
             dcc.Store(id="stream-start-time"),
             dcc.Store(id="detection-status", data="running"),  # or "stopped", etc.
             html.Div(id="dummy-output", style={"display": "none"}),
+            html.Div(id="dummy-output2", style={"display": "none"}),
             dcc.Store(id="pi_api_url"),
             dcc.Store(id="pi_cameras"),
             dcc.Store(id="current_camera"),
             dcc.Store(id="trigered_from_alert", data=True if available_stream else False),
             dcc.Store(id="hide-stream-flag", data=False),
+            dcc.Store(id="click-coords"),
+            dcc.Store(id="click-coords2"),
             dbc.Modal(
                 id="inactivity-modal",
                 is_open=False,

--- a/app/pages/live_stream.py
+++ b/app/pages/live_stream.py
@@ -126,7 +126,10 @@ translate = {
 def live_stream_layout(user_token, api_cameras, available_stream, selected_camera_info=None, lang="fr"):
     # Default fallback
     default_stream = next(iter(available_stream.keys()))[0] if available_stream else None
-    dropdown_options: List[Option] = [{"label": name, "value": name} for name in available_stream.keys()]
+
+    dropdown_options: List[dict[str, str]] = (
+        [{"label": name, "value": name} for name in available_stream.keys()] if available_stream else []
+    )
 
     # Try to derive stream from selected camera info
     if selected_camera_info and available_stream:

--- a/app/pages/live_stream.py
+++ b/app/pages/live_stream.py
@@ -3,7 +3,7 @@
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
-from typing import List, TypedDict
+from typing import List, Dict
 
 import dash_bootstrap_components as dbc
 from dash import dcc, html
@@ -11,10 +11,6 @@ from dash_extensions import EventListener  # type: ignore
 
 from utils.display import build_alerts_map
 
-
-class Option(TypedDict):
-    label: str
-    value: str
 
 
 # --- Styles ---
@@ -127,9 +123,11 @@ def live_stream_layout(user_token, api_cameras, available_stream, selected_camer
     # Default fallback
     default_stream = next(iter(available_stream.keys()))[0] if available_stream else None
 
-    dropdown_options: List[Option] = []
+    # Change the type hint here
+    dropdown_options: List[Dict[str, str]] = [] # <--- MODIFIED LINE
 
     if available_stream:
+        # This list comprehension already creates List[Dict[str, str]], which is fine
         dropdown_options = [{"label": name, "value": name} for name in available_stream.keys()]
 
     # Try to derive stream from selected camera info

--- a/app/pages/live_stream.py
+++ b/app/pages/live_stream.py
@@ -5,7 +5,7 @@
 
 import dash_bootstrap_components as dbc
 from dash import dcc, html
-from dash_extensions import EventListener
+from dash_extensions import EventListener # type: ignore
 
 from utils.display import build_alerts_map
 

--- a/app/pages/live_stream.py
+++ b/app/pages/live_stream.py
@@ -125,7 +125,7 @@ translate = {
 # --- Layout ---
 def live_stream_layout(user_token, api_cameras, available_stream, selected_camera_info=None, lang="fr"):
     # Default fallback
-    default_stream = list(available_stream.keys())[0] if available_stream else None
+    default_stream = next(iter(available_stream.keys()))[0] if available_stream else None
 
     # Try to derive stream from selected camera info
     if selected_camera_info and available_stream:

--- a/app/pages/live_stream.py
+++ b/app/pages/live_stream.py
@@ -8,6 +8,12 @@ from dash import dcc, html
 from dash_extensions import EventListener  # type: ignore
 
 from utils.display import build_alerts_map
+from typing import TypedDict, List
+
+class Option(TypedDict):
+    label: str
+    value: str
+
 
 # --- Styles ---
 STATUS_BAR_STYLE = {
@@ -118,6 +124,8 @@ translate = {
 def live_stream_layout(user_token, api_cameras, available_stream, selected_camera_info=None, lang="fr"):
     # Default fallback
     default_stream = next(iter(available_stream.keys()))[0] if available_stream else None
+    dropdown_options: List[Option] = [{"label": name, "value": name} for name in available_stream.keys()]
+
 
     # Try to derive stream from selected camera info
     if selected_camera_info and available_stream:
@@ -138,7 +146,7 @@ def live_stream_layout(user_token, api_cameras, available_stream, selected_camer
                                 id="available-stream-sites-dropdown",
                                 placeholder=translate[lang]["select_stream"],
                                 value=default_stream,
-                                options=[{"label": name, "value": name} for name in available_stream.keys()]
+                                options=dropdown_options
                                 if available_stream
                                 else [],
                                 style=PICK_STREAM_STYLE,

--- a/app/pages/live_stream.py
+++ b/app/pages/live_stream.py
@@ -127,9 +127,10 @@ def live_stream_layout(user_token, api_cameras, available_stream, selected_camer
     # Default fallback
     default_stream = next(iter(available_stream.keys()))[0] if available_stream else None
 
-    dropdown_options: List[dict[str, str]] = (
-        [{"label": name, "value": name} for name in available_stream.keys()] if available_stream else []
-    )
+    dropdown_options: List[Option] = []
+
+    if available_stream:
+        dropdown_options = [{"label": name, "value": name} for name in available_stream.keys()]
 
     # Try to derive stream from selected camera info
     if selected_camera_info and available_stream:

--- a/app/pages/live_stream.py
+++ b/app/pages/live_stream.py
@@ -96,11 +96,11 @@ STREAM_PAGE_STYLE = {
 }
 
 PICK_STREAM_STYLE = {
-                "width": "200px",
-                "marginRight": "10px",
-                "borderRadius": "6px",
-                "fontWeight": "bold",
-            }
+    "width": "200px",
+    "marginRight": "10px",
+    "borderRadius": "6px",
+    "fontWeight": "bold",
+}
 
 translate = {
     "fr": {
@@ -122,7 +122,6 @@ translate = {
 }
 
 
-
 # --- Layout ---
 def live_stream_layout(user_token, api_cameras, available_stream, selected_camera_info=None, lang="fr"):
     # Default fallback
@@ -139,34 +138,31 @@ def live_stream_layout(user_token, api_cameras, available_stream, selected_camer
         [
             # Status bar
             html.Div(
-    [
-            html.Div(id="stream-status", style=STREAM_STATUS_STYLE),
-
-            html.Div(
-                [  # GROUPED RIGHT SECTION
-                    dcc.Dropdown(
-                        id="available-stream-dropdown",
-                        placeholder=translate[lang]["select_stream"],
-                        value=default_stream,
-                        options=[
-                            {"label": name, "value": name}
-                            for name in available_stream.keys()
-                        ] if available_stream else [],
-                        style=PICK_STREAM_STYLE,
-                    ),
-                    html.Button(
-                        translate[lang]["close_doubt"],
-                        id="close-doubt",
-                        n_clicks=0,
-                        style=CLOSE_BUTTON_STYLE,
+                [
+                    html.Div(id="stream-status", style=STREAM_STATUS_STYLE),
+                    html.Div(
+                        [  # GROUPED RIGHT SECTION
+                            dcc.Dropdown(
+                                id="available-stream-dropdown",
+                                placeholder=translate[lang]["select_stream"],
+                                value=default_stream,
+                                options=[{"label": name, "value": name} for name in available_stream.keys()]
+                                if available_stream
+                                else [],
+                                style=PICK_STREAM_STYLE,
+                            ),
+                            html.Button(
+                                translate[lang]["close_doubt"],
+                                id="close-doubt",
+                                n_clicks=0,
+                                style=CLOSE_BUTTON_STYLE,
+                            ),
+                        ],
+                        style={"display": "flex", "alignItems": "center", "gap": "8px", "marginRight": "16px"},
                     ),
                 ],
-                style={"display": "flex", "alignItems": "center", "gap": "8px", "marginRight": "16px"},
+                style=STATUS_BAR_STYLE,
             ),
-        ],
-        style=STATUS_BAR_STYLE,
-    ),
-
             # Main layout: stream + map
             dbc.Row(
                 [
@@ -377,7 +373,7 @@ def live_stream_layout(user_token, api_cameras, available_stream, selected_camer
             # Hidden components
             dcc.Interval(id="stream-timer", interval=1000, n_intervals=0, disabled=True),
             dcc.Store(id="detection-status", data="stopped"),
-            html.Div(id="dummy-output", style={"display": "none"})
+            html.Div(id="dummy-output", style={"display": "none"}),
         ],
         style=STREAM_PAGE_STYLE,
     )

--- a/app/pages/live_stream.py
+++ b/app/pages/live_stream.py
@@ -1,0 +1,347 @@
+# Copyright (C) 2020-2025, Pyronear.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
+
+import dash_bootstrap_components as dbc
+import dash_leaflet as dl
+from dash import dcc, html
+
+from utils.display import build_vision_polygon
+
+# Constants
+site_lat = 48.426746125557
+site_lon = 2.71087590966019
+azimuth = 0
+opening_angle = 54
+dist_km = 15
+
+FASTAPI_URL = "http://<your_api_host>:8081"
+STREAM_URL = "http://<your_media_server>:8889/<your_stream_name>"
+
+CAMERAS = {
+    "Camera 1": {"ip": "192.168.1.10", "poses": [0, 1], "azimuths": [0, 90]},
+}
+
+# --- Styles ---
+STATUS_BAR_STYLE = {
+    "backgroundColor": "black",
+    "height": "50px",
+    "width": "100%",
+    "marginBottom": "8px",
+    "padding": "0",
+    "display": "flex",
+    "justifyContent": "space-between",
+    "alignItems": "center",
+}
+
+STREAM_STATUS_STYLE = {
+    "color": "white",
+    "fontWeight": "bold",
+    "fontSize": "16px",
+    "paddingLeft": "16px",
+    "height": "50px",
+    "display": "flex",
+    "alignItems": "center",
+}
+
+CLOSE_BUTTON_STYLE = {
+    "background": "none",
+    "border": "1px solid white",
+    "color": "white",
+    "borderRadius": "8px",
+    "padding": "6px 12px",
+    "cursor": "pointer",
+    "fontSize": "14px",
+    "marginRight": "16px",
+    "height": "36px",
+}
+
+BUTTON_STYLE = {
+    "background": "none",
+    "border": "none",
+    "fontSize": "28px",
+    "padding": "0",
+    "margin": "0",
+    "cursor": "pointer",
+}
+
+SLIDER_BOX_STYLE = {
+    "border": "2px solid #098386",
+    "borderRadius": "10px",
+    "padding": "8px",
+    "marginBottom": "16px",
+}
+
+DROPDOWN_STYLE = {
+    "border": "none",
+    "borderRadius": "8px",
+    "backgroundColor": "white",
+    "fontWeight": "bold",
+    "width": "100%",
+}
+
+WRAPPED_DROPDOWN_STYLE = {
+    "border": "2px solid #098386",
+    "borderRadius": "10px",
+    "marginBottom": "9px",
+}
+
+POSE_BUTTONS_STYLE = {
+    "display": "flex",
+    "flexWrap": "wrap",
+    "justifyContent": "center",
+    "gap": "8px",
+    "marginBottom": "9px",
+}
+
+STREAM_PAGE_STYLE = {
+    "padding": "0",
+    "margin": "0",
+    "width": "100%",
+    "height": "100%",
+}
+
+translate = {
+    "fr": {
+        "close_doubt": "Fermer la levée de doute",
+        "move_speed": "Vitesse de déplacement",
+        "zoom_level": "Niveau de zoom",
+        "start": "▶️ Démarrer",
+        "stop": "⏹️ Arrêter",
+    },
+    "es": {
+        "close_doubt": "Cerrar verificación visual",
+        "move_speed": "Velocidad de movimiento",
+        "zoom_level": "Nivel de zoom",
+        "start": "▶️ Iniciar",
+        "stop": "⏹️ Detener",
+    },
+}
+
+
+# --- Layout ---
+def live_stream_layout(user_token, api_cameras, lang="fr"):
+    return html.Div(
+        [
+            # Status bar
+            html.Div(
+                [
+                    html.Div(id="stream-status", style=STREAM_STATUS_STYLE),
+                    html.Button(translate[lang]["close_doubt"], id="close-doubt", n_clicks=0, style=CLOSE_BUTTON_STYLE),
+                ],
+                style=STATUS_BAR_STYLE,
+            ),
+            # Main layout: stream + map
+            dbc.Row(
+                [
+                    # LEFT COLUMN: Stream + Controls
+                    dbc.Col(
+                        [
+                            html.Div(
+                                [
+                                    html.Iframe(
+                                        id="video-stream",
+                                        src=STREAM_URL,
+                                        style={
+                                            "width": "100%",
+                                            "height": "500px",
+                                            "border": "none",
+                                            "borderRadius": "10px",
+                                        },
+                                    ),
+                                    # Joystick
+                                    html.Div(
+                                        [
+                                            dbc.Row(
+                                                [
+                                                    dbc.Col(),
+                                                    dbc.Col(
+                                                        html.Button("⬆️", id="move-up", n_clicks=0, style=BUTTON_STYLE)
+                                                    ),
+                                                    dbc.Col(),
+                                                ],
+                                                justify="center",
+                                            ),
+                                            dbc.Row(
+                                                [
+                                                    dbc.Col(
+                                                        html.Button("⬅️", id="move-left", n_clicks=0, style=BUTTON_STYLE)
+                                                    ),
+                                                    dbc.Col(
+                                                        html.Button(
+                                                            "🛑", id="stop-move", n_clicks=0, style=BUTTON_STYLE
+                                                        )
+                                                    ),
+                                                    dbc.Col(
+                                                        html.Button(
+                                                            "➡️", id="move-right", n_clicks=0, style=BUTTON_STYLE
+                                                        )
+                                                    ),
+                                                ],
+                                                justify="center",
+                                            ),
+                                            dbc.Row(
+                                                [
+                                                    dbc.Col(),
+                                                    dbc.Col(
+                                                        html.Button("⬇️", id="move-down", n_clicks=0, style=BUTTON_STYLE)
+                                                    ),
+                                                    dbc.Col(),
+                                                ],
+                                                justify="center",
+                                            ),
+                                        ],
+                                        style={
+                                            "position": "absolute",
+                                            "bottom": "10px",
+                                            "right": "10px",
+                                            "padding": "5px",
+                                            "borderRadius": "8px",
+                                        },
+                                    ),
+                                ],
+                                style={"position": "relative"},
+                            ),
+                            # Sliders
+                            dbc.Row(
+                                [
+                                    dbc.Col(
+                                        html.Div(
+                                            [
+                                                html.Div(
+                                                    translate[lang]["move_speed"],
+                                                    style={
+                                                        "textAlign": "center",
+                                                        "fontWeight": "bold",
+                                                        "marginBottom": "8px",
+                                                    },
+                                                ),
+                                                dcc.Slider(
+                                                    id="speed-input",
+                                                    min=0,
+                                                    max=100,
+                                                    step=10,
+                                                    value=0,
+                                                    marks={i: str(i) for i in range(0, 101, 10)},
+                                                ),
+                                            ],
+                                            style=SLIDER_BOX_STYLE,
+                                        ),
+                                        width=6,
+                                    ),
+                                    dbc.Col(
+                                        html.Div(
+                                            [
+                                                html.Div(
+                                                    translate[lang]["zoom_level"],
+                                                    style={
+                                                        "textAlign": "center",
+                                                        "fontWeight": "bold",
+                                                        "marginBottom": "8px",
+                                                    },
+                                                ),
+                                                dcc.Slider(
+                                                    id="zoom-input",
+                                                    min=0,
+                                                    max=100,
+                                                    step=10,
+                                                    value=0,
+                                                    marks={i: str(i) for i in range(0, 101, 10)},
+                                                ),
+                                            ],
+                                            style=SLIDER_BOX_STYLE,
+                                        ),
+                                        width=6,
+                                    ),
+                                ],
+                                className="mt-3",
+                            ),
+                        ],
+                        md=8,
+                        style={"padding": "0"},
+                    ),
+                    # RIGHT COLUMN: Dropdown + map
+                    dbc.Col(
+                        [
+                            html.Div(
+                                dcc.Dropdown(
+                                    id="camera-select",
+                                    options=[{"label": name, "value": name} for name in CAMERAS],
+                                    value=list(CAMERAS)[0] if CAMERAS else None,
+                                    clearable=False,
+                                    className="mb-2",
+                                    style=DROPDOWN_STYLE,
+                                ),
+                                style=WRAPPED_DROPDOWN_STYLE,
+                            ),
+                            # Start/Stop
+                            dbc.Row(
+                                [
+                                    dbc.Col(
+                                        html.Button(
+                                            translate[lang]["start"],
+                                            id="start-stream",
+                                            n_clicks=0,
+                                            style={
+                                                **BUTTON_STYLE,
+                                                "border": "2px solid #098386",
+                                                "borderRadius": "8px",
+                                                "fontSize": "18px",
+                                                "width": "100%",
+                                                "color": "#098386",
+                                            },
+                                        ),
+                                        width=6,
+                                    ),
+                                    dbc.Col(
+                                        html.Button(
+                                            translate[lang]["stop"],
+                                            id="stop-stream",
+                                            n_clicks=0,
+                                            style={
+                                                **BUTTON_STYLE,
+                                                "border": "2px solid #098386",
+                                                "borderRadius": "8px",
+                                                "fontSize": "18px",
+                                                "width": "100%",
+                                                "color": "#098386",
+                                            },
+                                        ),
+                                        width=6,
+                                    ),
+                                ],
+                                justify="center",
+                                className="mb-2",
+                            ),
+                            # Pose buttons
+                            html.Div(id="pose-buttons", style=POSE_BUTTONS_STYLE),
+                            # Map
+                            dl.Map(
+                                center=[site_lat, site_lon],
+                                zoom=10,
+                                children=[
+                                    dl.TileLayer(),
+                                    dl.LayerGroup(
+                                        id="vision-layer",
+                                        children=[
+                                            build_vision_polygon(site_lat, site_lon, azimuth, opening_angle, dist_km)[0]
+                                        ],
+                                    ),
+                                    dl.Marker(position=[site_lat, site_lon]),
+                                ],
+                                style={"width": "100%", "height": "350px", "borderRadius": "10px"},
+                            ),
+                        ],
+                        md=4,
+                        style={"padding": "0", "paddingLeft": "16px"},
+                    ),
+                ],
+                className="mb-4",
+            ),
+            # Hidden components
+            dcc.Interval(id="stream-timer", interval=1000, n_intervals=0, disabled=True),
+            dcc.Store(id="detection-status", data="stopped"),
+        ],
+        style=STREAM_PAGE_STYLE,
+    )

--- a/app/pages/live_stream.py
+++ b/app/pages/live_stream.py
@@ -5,7 +5,7 @@
 
 import dash_bootstrap_components as dbc
 from dash import dcc, html
-from dash_extensions import EventListener # type: ignore
+from dash_extensions import EventListener  # type: ignore
 
 from utils.display import build_alerts_map
 

--- a/app/pages/live_stream.py
+++ b/app/pages/live_stream.py
@@ -4,17 +4,9 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
 import dash_bootstrap_components as dbc
-import dash_leaflet as dl
 from dash import dcc, html
 
-from utils.display import build_vision_polygon
-
-# Constants
-site_lat = 48.426746125557
-site_lon = 2.71087590966019
-azimuth = 0
-opening_angle = 54
-dist_km = 15
+from utils.display import build_alerts_map
 
 # --- Styles ---
 STATUS_BAR_STYLE = {
@@ -22,6 +14,7 @@ STATUS_BAR_STYLE = {
     "height": "50px",
     "width": "100%",
     "marginBottom": "8px",
+    "marginTop": "0",
     "padding": "0",
     "display": "flex",
     "justifyContent": "space-between",
@@ -348,20 +341,18 @@ def live_stream_layout(user_token, api_cameras, available_stream, selected_camer
                             # Pose buttons
                             html.Div(id="pose-buttons", style=POSE_BUTTONS_STYLE),
                             # Map
-                            dl.Map(
-                                center=[site_lat, site_lon],
-                                zoom=10,
-                                children=[
-                                    dl.TileLayer(),
-                                    dl.LayerGroup(
-                                        id="vision-layer",
-                                        children=[
-                                            build_vision_polygon(site_lat, site_lon, azimuth, opening_angle, dist_km)[0]
-                                        ],
-                                    ),
-                                    dl.Marker(position=[site_lat, site_lon]),
-                                ],
-                                style={"width": "100%", "height": "350px", "borderRadius": "10px"},
+                            html.Div(
+                                dbc.Col(
+                                    build_alerts_map(api_cameras, id_suffix="-stream"),
+                                    className="common-style",
+                                    style={
+                                        "position": "relative",
+                                        "width": "100%",
+                                        "height": "400px",
+                                        "borderRadius": "10px",
+                                        "overflow": "hidden",
+                                    },
+                                )
                             ),
                         ],
                         md=4,

--- a/app/utils/display.py
+++ b/app/utils/display.py
@@ -81,7 +81,7 @@ def calculate_new_polygon_parameters(azimuth, opening_angle, bboxes):
     This function compute the vision polygon parameters based on bboxes
     """
     # Assuming bboxes is in the format [x0, y0, x1, y1, confidence]
-    x0, _, width, _ = bboxes
+    x0, _, width, _ = bboxes[:4]
     xc = (x0 + width / 2) / 100
 
     # New azimuth
@@ -118,15 +118,15 @@ def build_sites_markers(api_cameras):
     markers = []
 
     for _, site in client_sites.iterrows():
-        site_id = site["id"]
         lat = round(site["lat"], 4)
         lon = round(site["lon"], 4)
-        site_name = site["name"][:-3].replace("_", " ").title()
+        site_name = site["name"][:-3].replace("_", " ").lower()
         markers.append(
             dl.Marker(
-                id=f"site_{site_id}",  # Necessary to set an id for each marker to receive callbacks
+                id={"type": "site-marker", "index": site_name.lower()},
                 position=(lat, lon),
                 icon=icon,
+                n_clicks=0,  # ✅ allows click tracking
                 children=[
                     dl.Tooltip(site_name),
                     dl.Popup(

--- a/app/utils/display.py
+++ b/app/utils/display.py
@@ -143,7 +143,7 @@ def build_sites_markers(api_cameras):
     return markers, client_sites
 
 
-def build_vision_polygon(site_lat, site_lon, azimuth, opening_angle, dist_km, bboxes=None):
+def build_vision_polygon(site_lat, site_lon, azimuth, opening_angle, dist_km, bboxes=[]):
     """
     Create a vision polygon using dl.Polygon. This polygon is placed on the map using alerts data.
     """

--- a/app/utils/display.py
+++ b/app/utils/display.py
@@ -143,11 +143,11 @@ def build_sites_markers(api_cameras):
     return markers, client_sites
 
 
-def build_vision_polygon(site_lat, site_lon, azimuth, opening_angle, dist_km, bboxes=[]):
+def build_vision_polygon(site_lat, site_lon, azimuth, opening_angle, dist_km, bboxes=None):
     """
     Create a vision polygon using dl.Polygon. This polygon is placed on the map using alerts data.
     """
-    if len(bboxes):
+    if bboxes is not None:
         azimuth, opening_angle = calculate_new_polygon_parameters(azimuth, opening_angle, bboxes[0])
 
     # The center corresponds the point from which the vision angle "starts"

--- a/app/utils/live_stream.py
+++ b/app/utils/live_stream.py
@@ -7,6 +7,15 @@
 import requests
 
 
+# API Communication
+def send_api_request(FASTAPI_URL, endpoint: str):
+    try:
+        response = requests.post(f"{FASTAPI_URL}{endpoint}")
+        return response.json().get("message", "Unknown response")
+    except requests.exceptions.RequestException:
+        return "Error: Could not reach API server."
+
+
 def fetch_cameras(pi_api_url):
     """Fetch camera data from pi
 

--- a/app/utils/live_stream.py
+++ b/app/utils/live_stream.py
@@ -1,7 +1,6 @@
 import requests
 
 
-
 def fetch_cameras(pi_api_url):
     """Fetch camera data from pi
 

--- a/app/utils/live_stream.py
+++ b/app/utils/live_stream.py
@@ -7,6 +7,13 @@
 import requests
 
 
+# FOV based on zoom input
+def fov_zoom(z):
+    if z == 0:
+        return 54.2
+    return 55.59044 - 2.00815 * z + 0.01886 * z**2
+
+
 # API Communication
 def send_api_request(FASTAPI_URL, endpoint: str):
     try:

--- a/app/utils/live_stream.py
+++ b/app/utils/live_stream.py
@@ -1,3 +1,9 @@
+# Copyright (C) 2020-2025, Pyronear.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
+
+
 import requests
 
 
@@ -32,7 +38,7 @@ def find_closest_camera_pose(target_azimuth, pi_cameras):
 
     for cam_name, cam_data in pi_cameras.items():
         ip = cam_data["ip"]
-        for pose_id, az in zip(cam_data["poses"], cam_data["azimuths"]):
+        for pose_id, az in zip(cam_data["poses"], cam_data["azimuths"], strict=True):
             diff = min(abs(az - target_azimuth), 360 - abs(az - target_azimuth))  # circular difference
             if diff < min_diff:
                 min_diff = diff

--- a/app/utils/live_stream.py
+++ b/app/utils/live_stream.py
@@ -1,0 +1,47 @@
+import requests
+
+
+
+def fetch_cameras(pi_api_url):
+    """Fetch camera data from pi
+
+    Args:
+        pi_api_url (_type_): live stream api ruinig on pi
+    """
+    try:
+        response = requests.get(f"{pi_api_url}/camera_infos")
+        response.raise_for_status()
+        data = response.json()
+        cameras = {}
+        for cam in data.get("cameras", []):
+            name = cam.get("name", f"Camera {cam.get('id')}")
+            if name:
+                cameras[name] = {
+                    "ip": cam.get("ip"),
+                    "poses": cam.get("poses", []),
+                    "azimuths": cam.get("azimuths", []),
+                }
+        return cameras
+    except Exception as e:
+        print(f"Error fetching cameras: {e}")
+        return {}
+
+
+def find_closest_camera_pose(target_azimuth, pi_cameras):
+    closest_info = None
+    min_diff = float("inf")
+
+    for cam_name, cam_data in pi_cameras.items():
+        ip = cam_data["ip"]
+        for pose_id, az in zip(cam_data["poses"], cam_data["azimuths"]):
+            diff = min(abs(az - target_azimuth), 360 - abs(az - target_azimuth))  # circular difference
+            if diff < min_diff:
+                min_diff = diff
+                closest_info = {
+                    "camera": cam_name,
+                    "ip": ip,
+                    "azimuth": az,
+                    "pose": pose_id,
+                }
+
+    return closest_info

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -9,6 +9,7 @@ services:
       - 8050:8050
     volumes:
       - ./app/:/usr/src/app/
+      - available_stream.json:/usr/src/app/available_stream.json
     environment:
       - API_URL=${API_URL}
       - API_LOGIN=${API_LOGIN}

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -9,7 +9,7 @@ services:
       - 8050:8050
     volumes:
       - ./app/:/usr/src/app/
-      - available_stream.json:/usr/src/app/available_stream.json
+      - ./available_stream.json:/usr/src/app/available_stream.json
     environment:
       - API_URL=${API_URL}
       - API_LOGIN=${API_LOGIN}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - 8050
     volumes:
       - ./app/:/usr/src/app/
+      - available_stream.json:/usr/src/app/available_stream.json
     environment:
       - API_URL=${API_URL}
       - API_LOGIN=${API_LOGIN}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - 8050
     volumes:
       - ./app/:/usr/src/app/
-      - available_stream.json:/usr/src/app/available_stream.json
+      - ./available_stream.json:/usr/src/app/available_stream.json
     environment:
       - API_URL=${API_URL}
       - API_LOGIN=${API_LOGIN}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ python = "^3.11"
 dash = ">=2.14.0"
 dash-bootstrap-components = ">=1.5.0"
 dash-leaflet = "^0.1.4"
+dash-extensions= ">=2.0.4"
 pandas = ">=2.1.4"
 pyroclient = { git = "https://github.com/pyronear/pyro-api.git", branch = "main", subdirectory = "client" }
 python-dotenv = ">=1.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ preview = true
 [tool.ruff.per-file-ignores]
 "**/__init__.py" = ["I001", "F401", "CPY001"]
 ".github/**.py" = ["D"]
+"app/index.py" = ["F401"]
 
 [tool.ruff.isort]
 known-first-party = ["config", "pages", "components", "utils", "services"]


### PR DESCRIPTION
This PR introduces a fully interactive stream page that enables real-time control and monitoring of camera streams. It includes:

🚀 Key Features:
	•	Live camera streaming with dynamic URL switching based on selected site
	•	Clickable video overlay to move the PTZ camera by clicking directly on the stream
	•	Manual camera control:
	•	Directional movement (↑ ↓ ← →)
	•	Zoom control via slider
	•	Automatic movement to preset positions
	•	Inactivity timer with modal warning and stream auto-hiding after 2 minutes of inactivity
	•	Vision cone overlay based on current camera pose, zoom level, and azimuth
	•	Snapshot capture: Capture the current stream view and display it in a modal with download support
	•	Stream status banner showing elapsed time and last command delta
	•	Multiple callbacks to sync camera state, preset azimuths, and UI elements

🔧 Refactoring & Internals:
	•	Unified logging across callbacks (logger)
	•	Global last_command_time to manage stream activity tracking
	•	Modular camera pose update logic (find_closest_camera_pose)
	•	Improved error handling for stream and capture operations
	•	Added index_string customization for click event capture

📌 Notes:
	•	This page relies on a MEDIAMTX_SERVER_IP and /start_stream/{camera_ip} backend endpoint to start streaming.
	•	Vision cone is generated based on build_vision_polygon() and camera FOV logic tied to zoom.
	•	Click-to-move sensitivity is calibrated using FOV projections