### PR TITLE
use url

### DIFF
--- a/app/callbacks/live_callbacks.py
+++ b/app/callbacks/live_callbacks.py
@@ -431,7 +431,7 @@ def update_stream_url(site_name, hide_flag):
     if not site_name:
         raise PreventUpdate
 
-    return f"{cfg.MEDIAMTX_SERVER_IP}:8889/{site_name}"
+    return f"{cfg.MEDIAMTX_SERVER_URL}/{site_name}"
 
 
 @app.callback(

--- a/app/config.py
+++ b/app/config.py
@@ -30,7 +30,7 @@ SERVER_NAME: Optional[str] = os.getenv("SERVER_NAME")
 SAFE_DEV_MODE: Optional[str] = os.getenv("SAFE_DEV_MODE")
 
 # Stream server
-MEDIAMTX_SERVER_IP = os.environ.get("MEDIAMTX_SERVER_IP", "")
+MEDIAMTX_SERVER_URL = os.environ.get("MEDIAMTX_SERVER_URL", "")
 
 # App config variables
 MAX_ALERTS_PER_EVENT = 10


### PR DESCRIPTION
In order to setup DNS let's use url instead of ip + port