### PR TITLE
Fix S3 upload error due to streaming payload

### DIFF
--- a/app/callbacks/display_callbacks.py
+++ b/app/callbacks/display_callbacks.py
@@ -7,7 +7,7 @@ import ast
 import json
 import os
 from datetime import date, datetime, timedelta, timezone
-from io import StringIO
+from io import BytesIO, StringIO
 
 import boto3
 import dash
@@ -766,10 +766,12 @@ def handle_modal(create_clicks, confirm_clicks, delete_clicks, camera_info, sequ
             bboxes_dict = {}
 
         try:
+            json_bytes = json.dumps(bboxes_dict, indent=2).encode("utf-8")
+            byte_buffer = BytesIO(json_bytes)
             s3_client.put_object(
                 Bucket=bucket_name,
                 Key=object_key,
-                Body=json.dumps(bboxes_dict, indent=2).encode("utf-8"),
+                Body=byte_buffer,
                 ContentType="application/json",
                 ACL="public-read",
             )


### PR DESCRIPTION
This PR updates the S3 put_object call to use an in-memory BytesIO buffer instead of passing raw bytes directly. This avoids triggering the aws-chunked transfer encoding, which is not supported by the OVH S3-compatible API and was causing InvalidArgument errors