### PR TITLE
fix error reading detection

### DIFF
--- a/app/callbacks/data_callbacks.py
+++ b/app/callbacks/data_callbacks.py
@@ -294,7 +294,13 @@ def load_detections(api_sequences, sequence_id_on_display, api_detections, are_d
         # If the displayed sequence changes, load its detections if not already loaded
         if sequence_id_on_display not in api_detections:
             response = api_client.fetch_sequences_detections(sequence_id_on_display)
-            detections = pd.DataFrame(response.json())
+            data = response.json()
+            if isinstance(data, list):
+                detections = pd.DataFrame(data)
+            else:
+                detections = pd.DataFrame()
+                logger.error("Error Reading detection")
+
             if not detections.empty and "bboxes" in detections.columns:
                 detections = detections.iloc[::-1].reset_index(drop=True)
                 detections["processed_bboxes"] = detections["bboxes"].apply(process_bbox)
@@ -316,7 +322,13 @@ def load_detections(api_sequences, sequence_id_on_display, api_detections, are_d
 
             if sequence_id not in are_detections_loaded or are_detections_loaded[sequence_id] != str(last_seen_at):
                 response = api_client.fetch_sequences_detections(sequence_id)
-                detections = pd.DataFrame(response.json())
+                data = response.json()
+                if isinstance(data, list):
+                    detections = pd.DataFrame(data)
+                else:
+                    detections = pd.DataFrame()
+                    logger.error("Error Reading detection")
+
                 if not detections.empty and "bboxes" in detections.columns:
                     detections = detections.iloc[::-1].reset_index(drop=True)
                     detections["processed_bboxes"] = detections["bboxes"].apply(process_bbox)

--- a/app/layouts/main_layout.py
+++ b/app/layouts/main_layout.py
@@ -61,7 +61,7 @@ def get_main_layout():
                 storage_type="session",
                 data=pd.DataFrame().to_json(orient="split"),
             ),
-            dcc.Store(id="sequence_id_on_display", data=0),
+            dcc.Store(id="sequence_id_on_display", storage_type="session", data=0),
             dcc.Store(id="auto-move-state", data={"active": True}),
             # Add this to your app.layout
             dcc.Store(id="bbox_visibility", data={"visible": True}),


### PR DESCRIPTION
Fixing 


```
Traceback (most recent call last):
  File "/usr/src/app/callbacks/data_callbacks.py", line 297, in load_detections
    detections = pd.DataFrame(response.json())
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/pandas/core/frame.py", line 778, in __init__
    mgr = dict_to_mgr(data, index, columns, dtype=dtype, copy=copy, typ=manager)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/pandas/core/internals/construction.py", line 503, in dict_to_mgr
    return arrays_to_mgr(arrays, columns, index, dtype=dtype, typ=typ, consolidate=copy)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/pandas/core/internals/construction.py", line 114, in arrays_to_mgr
    index = _extract_index(arrays)
            ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/pandas/core/internals/construction.py", line 667, in _extract_index
    raise ValueError("If using all scalar values, you must pass an index")
ValueError: If using all scalar values, you must pass an index
```