### PR TITLE
add nav actions

### DIFF
--- a/app/callbacks/display_callbacks.py
+++ b/app/callbacks/display_callbacks.py
@@ -609,6 +609,17 @@ def toggle_datepicker_modal(open_click, close_click, is_open):
 
 
 @app.callback(
+    Output("my-date-picker-single", "date", allow_duplicate=True),
+    Input("home-button", "n_clicks"),
+    prevent_initial_call=True,
+)
+def reset_date_picker(n_clicks):
+    if n_clicks:
+        return None
+    raise PreventUpdate
+
+
+@app.callback(
     Output("my-date-picker-single", "min_date_allowed"),
     Output("my-date-picker-single", "max_date_allowed"),
     Output("my-date-picker-single", "initial_visible_month"),

--- a/app/index.py
+++ b/app/index.py
@@ -32,6 +32,7 @@ app.layout = get_main_layout()
 
 
 # Manage Pages
+# Manage Pages
 @app.callback(
     Output("page-content", "children"),
     [
@@ -40,10 +41,13 @@ app.layout = get_main_layout()
         Input("url", "search"),
         Input("selected-camera-info", "data"),
         Input("language", "data"),
+        Input("my-date-picker-single", "date"),
     ],
     [State("user_token", "data"), State("available-stream-sites", "data")],
 )
-def display_page(pathname, api_cameras, search, selected_camera_info, lang, user_token, available_stream):
+def display_page(
+    pathname, api_cameras, search, selected_camera_info, lang, selected_date, user_token, available_stream
+):
     logger.debug("display_page called with pathname: %s, user_token: %s using lang %s", pathname, user_token, lang)
 
     if not isinstance(user_token, str) or not user_token:
@@ -54,8 +58,9 @@ def display_page(pathname, api_cameras, search, selected_camera_info, lang, user
     if triggered == "selected-camera-info" and selected_camera_info:
         return live_stream_layout(user_token, api_cameras, available_stream, selected_camera_info, lang=lang)
 
-    if pathname == "/" or pathname is None:
+    if (pathname == "/" or pathname is None) or triggered == "my-date-picker-single":
         return homepage_layout(user_token, api_cameras, lang=lang)
+
     if pathname == "/cameras-status":
         return cameras_status_layout(user_token, api_cameras, lang=lang)
     if pathname == "/blinking-alarm":


### PR DESCRIPTION
We are adding two features requested by the firefighters in this pull request:

If we click on a date, we should see the alerts, no matter which page we are on

If we click on the "Alerts" button, we return to today's alerts