### PR TITLE
Change display order

### DIFF
--- a/app/callbacks/data_callbacks.py
+++ b/app/callbacks/data_callbacks.py
@@ -136,11 +136,10 @@ def login_callback(n_clicks, username, password, user_token, lang):
 
 from dash import Input, Output, State, callback
 
-
 @callback(
-    Output("detection_fetch_limit", "data"),
-    Input("detection_fetch_limit_input", "value"),
-    prevent_initial_call=True,  # optional, remove if you want it to run on first load
+    Output('detection_fetch_limit', 'data'),
+    Input('detection_fetch_limit_input', 'value'),
+    prevent_initial_call=True  # optional, remove if you want it to run on first load
 )
 def update_fetch_limit(value):
     if value is None:
@@ -223,7 +222,7 @@ def api_cameras_watcher(n_intervals, api_cameras, user_token):
         Input("api_cameras", "data"),
         Input("to_acknowledge", "data"),
         Input("unmatched_event_id_table", "data"),
-        Input("my-date-picker-single", "date"),
+        Input("my-date-picker-single", "date")
     ],
     [State("api_sequences", "data"), State("user_token", "data"), State("event_id_table", "data")],
     prevent_initial_call=True,
@@ -300,8 +299,6 @@ def api_watcher(
                 api_sequences, unmatched_event_table=unmatched_event_id_table
             )
 
-            print("event_id_table")
-            print(event_id_table)
             local_event_id_table = pd.read_json(StringIO(local_event_id_table), orient="split")
 
             # Load local sequences safely
@@ -320,7 +317,10 @@ def api_watcher(
             event_condition = event_id_table.empty or (
                 "sequences" in local_event_id_table.columns
                 and "sequences" in event_id_table.columns
-                and np.array_equal(local_event_id_table["sequences"].values, event_id_table["sequences"].values)
+                and np.array_equal(
+                    local_event_id_table["sequences"].values,
+                    event_id_table["sequences"].values
+                )
             )
 
             # Now apply sequence comparison only if event condition is true
@@ -329,6 +329,8 @@ def api_watcher(
                     if not sequences_have_changed(api_sequences, local_sequences_df):
                         logger.info("Skipping update: no significant change detected")
                         return dash.no_update
+
+
 
         return api_sequences.to_json(orient="split"), event_id_table.to_json(orient="split")
 

--- a/app/callbacks/data_callbacks.py
+++ b/app/callbacks/data_callbacks.py
@@ -375,8 +375,6 @@ def load_detections(
     if user_token is None or sequence_id_on_display is None:
         raise PreventUpdate
 
-    print("load_detections", detection_fetch_limit, detection_fetch_desc)
-
     detection_fetch_desc = detection_fetch_desc if detection_fetch_desc else False
 
     try:
@@ -396,22 +394,13 @@ def load_detections(
 
     detection_key = f"{sequence_id_on_display}_{detection_fetch_limit}_{detection_fetch_desc}"
 
-    print("api_detections", detection_key)
-
-    print(api_detections.keys())
-
     if detection_key not in api_detections.keys():
         try:
-            print("FETching DATA", sequence_id_on_display, detection_fetch_limit, detection_fetch_desc)
             response = client.fetch_sequences_detections(
                 sequence_id=sequence_id_on_display, limit=detection_fetch_limit, desc=detection_fetch_desc
             )
             data = response.json()
             detections = pd.DataFrame(data) if isinstance(data, list) else pd.DataFrame()
-
-            print("DETECTION")
-            print(detections)
-            print("dd")
 
             if not detections.empty and "bboxes" in detections.columns:
                 detections = detections.iloc[::-1].reset_index(drop=True)
@@ -434,10 +423,6 @@ def load_detections(
             return dash.no_update, dash.no_update, dash.no_update
 
     sequence_on_display = api_detections[detection_key]
-
-    sequence_on_displayDF = pd.read_json(StringIO(sequence_on_display), orient="split")
-
-    print(sequence_on_displayDF)
 
     return json.dumps(are_detections_loaded), sequence_on_display, json.dumps(api_detections)
 

--- a/app/callbacks/data_callbacks.py
+++ b/app/callbacks/data_callbacks.py
@@ -136,10 +136,11 @@ def login_callback(n_clicks, username, password, user_token, lang):
 
 from dash import Input, Output, State, callback
 
+
 @callback(
-    Output('detection_fetch_limit', 'data'),
-    Input('detection_fetch_limit_input', 'value'),
-    prevent_initial_call=True  # optional, remove if you want it to run on first load
+    Output("detection_fetch_limit", "data"),
+    Input("detection_fetch_limit_input", "value"),
+    prevent_initial_call=True,  # optional, remove if you want it to run on first load
 )
 def update_fetch_limit(value):
     if value is None:
@@ -222,7 +223,7 @@ def api_cameras_watcher(n_intervals, api_cameras, user_token):
         Input("api_cameras", "data"),
         Input("to_acknowledge", "data"),
         Input("unmatched_event_id_table", "data"),
-        Input("my-date-picker-single", "date")
+        Input("my-date-picker-single", "date"),
     ],
     [State("api_sequences", "data"), State("user_token", "data"), State("event_id_table", "data")],
     prevent_initial_call=True,
@@ -317,10 +318,7 @@ def api_watcher(
             event_condition = event_id_table.empty or (
                 "sequences" in local_event_id_table.columns
                 and "sequences" in event_id_table.columns
-                and np.array_equal(
-                    local_event_id_table["sequences"].values,
-                    event_id_table["sequences"].values
-                )
+                and np.array_equal(local_event_id_table["sequences"].values, event_id_table["sequences"].values)
             )
 
             # Now apply sequence comparison only if event condition is true
@@ -329,8 +327,6 @@ def api_watcher(
                     if not sequences_have_changed(api_sequences, local_sequences_df):
                         logger.info("Skipping update: no significant change detected")
                         return dash.no_update
-
-
 
         return api_sequences.to_json(orient="split"), event_id_table.to_json(orient="split")
 

--- a/app/index.py
+++ b/app/index.py
@@ -58,8 +58,11 @@ def display_page(
     if triggered == "selected-camera-info" and selected_camera_info:
         return live_stream_layout(user_token, api_cameras, available_stream, selected_camera_info, lang=lang)
 
-    if (pathname == "/" or pathname is None) or triggered == "my-date-picker-single":
-        return homepage_layout(user_token, api_cameras, lang=lang)
+    if triggered == "my-date-picker-single":
+        return homepage_layout(user_token, api_cameras, lang=lang, descending_order=False)
+
+    if pathname in ["/", None]:
+        return homepage_layout(user_token, api_cameras, lang=lang, descending_order=True)
 
     if pathname == "/cameras-status":
         return cameras_status_layout(user_token, api_cameras, lang=lang)

--- a/app/layouts/main_layout.py
+++ b/app/layouts/main_layout.py
@@ -86,4 +86,5 @@ def get_main_layout():
         dcc.Store(id="selected-camera-info", storage_type="session"),
         dcc.Store(id="language", storage_type="session", data="fr"),
         dcc.Store(id="selected_event_id", storage_type="session", data=None),
+        dcc.Store(id="detection_fetch_limit", storage_type="session", data=10),
     ])

--- a/app/pages/homepage.py
+++ b/app/pages/homepage.py
@@ -16,7 +16,31 @@ def homepage_layout(user_token, api_cameras, lang="fr"):
     return dbc.Container(
         [
             dbc.Row([
-                dbc.Col([create_event_list()], width=2, className="mb-4"),
+                dbc.Col(
+                    [
+                        html.Label(translate("detections_to_fetch", lang), className="mt-2"),
+                        dcc.Input(
+                            id="detection_fetch_limit_input",
+                            type="number",
+                            min=1,
+                            max=50,
+                            step=1,
+                            value=10,
+                            style={"width": "100%"},
+                        ),
+                        html.Label(translate("fetch_order", lang), className="mt-3"),
+                        dbc.Checklist(
+                            id="detection_fetch_desc",
+                            options=[{"value": True}],
+                            value=[True],
+                            switch=True,
+                        ),
+                        html.Hr(className="my-3"),
+                        create_event_list(),
+                    ],
+                    width=2,
+                    className="mb-4",
+                ),
                 dbc.Col(
                     [
                         html.Div(

--- a/app/pages/homepage.py
+++ b/app/pages/homepage.py
@@ -12,7 +12,7 @@ from components.alerts import create_event_list
 from utils.display import build_alerts_map
 
 
-def homepage_layout(user_token, api_cameras, lang="fr"):
+def homepage_layout(user_token, api_cameras, lang="fr", descending_order=True):
     return dbc.Container(
         [
             dbc.Row([
@@ -35,7 +35,7 @@ def homepage_layout(user_token, api_cameras, lang="fr"):
                             dbc.Checklist(
                                 id="detection_fetch_desc",
                                 options=[{"value": True}],
-                                value=[True],
+                                value=[descending_order],
                                 switch=True,
                             ),
                             html.Hr(className="my-3"),

--- a/app/pages/homepage.py
+++ b/app/pages/homepage.py
@@ -17,27 +17,31 @@ def homepage_layout(user_token, api_cameras, lang="fr"):
         [
             dbc.Row([
                 dbc.Col(
-                    [
-                        html.Label(translate("detections_to_fetch", lang), className="mt-2"),
-                        dcc.Input(
-                            id="detection_fetch_limit_input",
-                            type="number",
-                            min=1,
-                            max=50,
-                            step=1,
-                            value=10,
-                            style={"width": "100%"},
-                        ),
-                        html.Label(translate("fetch_order", lang), className="mt-3"),
-                        dbc.Checklist(
-                            id="detection_fetch_desc",
-                            options=[{"value": True}],
-                            value=[True],
-                            switch=True,
-                        ),
-                        html.Hr(className="my-3"),
-                        create_event_list(),
-                    ],
+                    html.Div(
+                        className="common-style",
+                        style={"padding": "8px"},
+                        children=[
+                            html.Label(translate("detections_to_fetch", lang), className="mt-2"),
+                            dcc.Input(
+                                id="detection_fetch_limit_input",
+                                type="number",
+                                min=1,
+                                max=50,
+                                step=1,
+                                value=10,
+                                style={"width": "100%"},
+                            ),
+                            html.Label(translate("fetch_order", lang), className="mt-3"),
+                            dbc.Checklist(
+                                id="detection_fetch_desc",
+                                options=[{"value": True}],
+                                value=[True],
+                                switch=True,
+                            ),
+                            html.Hr(className="my-3"),
+                            create_event_list(),
+                        ],
+                    ),
                     width=2,
                     className="mb-4",
                 ),

--- a/app/translations.py
+++ b/app/translations.py
@@ -46,6 +46,8 @@ translate_dict = {
         "start_time": "Début à ",
         "end_time": "Fin à ",
         "unmatch-sequence": "Dissocier la séquence",
+        "detections_to_fetch": "Afficher :",
+        "fetch_order": "Afficher les plus récentes",
         # live stream
         "move_speed": "Vitesse de déplacement",
         "zoom_level": "Niveau de zoom",
@@ -108,6 +110,10 @@ translate_dict = {
         "start_time": "Inicio a las ",
         "end_time": "Fin a las ",
         "unmatch-sequence": "Desvincular secuencia",
+        "detections_to_fetch": "Número de detecciones a cargar",
+        "fetch_order": "Orden de recuperación",
+        "detections_to_fetch": "Mostrar:",
+        "fetch_order": "Mostrar las más recientes",
         # live stream
         "move_speed": "Velocidad de movimiento",
         "zoom_level": "Nivel de zoom",
@@ -170,6 +176,8 @@ translate_dict = {
         "start_time": "Start at ",
         "end_time": "End at ",
         "unmatch-sequence": "Unmatch sequence",
+        "detections_to_fetch": "Show:",
+        "fetch_order": "Show latest first",
         # live stream
         "move_speed": "Movement Speed",
         "zoom_level": "Zoom Level",


### PR DESCRIPTION
For some time now, the API has offered more flexibility in selecting alerts by allowing the number of alerts to be displayed to be changed, as well as the order in which they are retrieved

We are now adding this capability to the platform