### PR TITLE
add location info

### DIFF
--- a/app/pages/homepage.py
+++ b/app/pages/homepage.py
@@ -409,7 +409,7 @@ def homepage_layout(user_token, api_cameras, lang="fr", descending_order=True):
                                                         children=[
                                                             html.Span(
                                                                 id="smoke-location-copy-content",
-                                                                children="48.5595, 2.5468",  # Or dynamically updated
+                                                                children="",
                                                                 style={"marginRight": "6px", "whiteSpace": "nowrap"},
                                                             ),
                                                             dcc.Clipboard(
@@ -426,6 +426,15 @@ def homepage_layout(user_token, api_cameras, lang="fr", descending_order=True):
                                                         ],
                                                     ),
                                                 ],
+                                            ),
+                                            html.Div(
+                                                id="alert-location-parcel-info",
+                                                style={
+                                                    "display": "block",
+                                                    "margin": "0",
+                                                    "padding": "0",
+                                                    "lineHeight": "1",
+                                                },
                                             ),
                                         ],
                                     ),

--- a/app/translations.py
+++ b/app/translations.py
@@ -49,6 +49,8 @@ translate_dict = {
         "unmatch-sequence": "Dissocier la séquence",
         "detections_to_fetch": "Afficher :",
         "fetch_order": "Afficher les plus récentes",
+        "localisation": "Localisation",
+        "onf_parcel": "Parcelle ONF",
         # live stream
         "move_speed": "Vitesse de déplacement",
         "zoom_level": "Niveau de zoom",
@@ -125,6 +127,8 @@ translate_dict = {
         "fetch_order": "Orden de recuperación",
         "detections_to_fetch": "Mostrar:",
         "fetch_order": "Mostrar las más recientes",
+        "localisation": "Localización",
+        "onf_parcel": "Parcela ONF",
         # live stream
         "move_speed": "Velocidad de movimiento",
         "zoom_level": "Nivel de zoom",
@@ -218,6 +222,8 @@ translate_dict = {
         "live_stream_warning": "⚠️ Verification in progress: detection inactive!",
         "loading_modal_title": "Stream is loading...",
         "loading_modal_body": "Please wait.",
+        "localisation": "Location",
+        "onf_parcel": "ONF Parcel",
         # login
         "username_placeholder": "USERNAME",
         "password_placeholder": "PASSWORD",


### PR DESCRIPTION
At the request of firefighters, we have added API calls to automatically retrieve location details based on triangulated coordinates. This includes identifying the city and, when available, the corresponding ONF forest parcel number

The get_location_info(lat, lon) function first performs reverse geocoding using OpenStreetMap’s Nominatim service to extract administrative information such as the city, country, and country code. If the location is in France, the function then queries the national forest parcel database (hosted by IGN) to check whether the point intersects with a public forest parcel managed by the ONF. If so, it returns the full parcel attributes