### PR TITLE
Renamed tab name

### DIFF
--- a/app/callbacks/live_callbacks.py
+++ b/app/callbacks/live_callbacks.py
@@ -510,7 +510,7 @@ app.index_string = """
 <html>
     <head>
         {%metas%}
-        <title>Clickable Stream</title>
+        <title>Pyronear</title>
         {%favicon%}
         {%css%}
         <script>


### PR DESCRIPTION
Currently, when users bookmark the platform in their browser or create a shortcut on their desktop, the default name is ‘Clickable Stream’ (see screenshot below)

Hence, this small PR modifies the wording to 'Pyronear' which is more explicit and avoid further renaming or ambiguity !

happy to discuss it !

<img width="430" height="105" alt="Capture d’écran 2025-08-13 à 17 45 43" src="https://github.com/user-attachments/assets/554028d0-1e17-42a6-8acf-76d20bd9b0d9" />

